### PR TITLE
Improve lint checks

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+scripts/
+dist/
+reports/

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,5 @@
         "no-only-tests"
     ],
     "rules": {
-        "max-len": ["warn", 200]
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,5 +10,6 @@
         "no-only-tests"
     ],
     "rules": {
+        "max-len": ["warn", 120]
     }
 }

--- a/__integrations__/schemas/PublicSchemasValidation.test.js
+++ b/__integrations__/schemas/PublicSchemasValidation.test.js
@@ -6,7 +6,8 @@ const credentialDefinitions = require('../../src/creds/definitions');
 const ucaDefinitions = require('../../src/uca/definitions');
 
 const fixturesPath = '__integrations__/fixtures';
-// testings is done only on the test bucket, since we only release to production on manual CircleCI flow
+// testings is done only on the test bucket,
+// since we only release to production on manual CircleCI flow
 // check process env for S3 SChema URL or fallback to an fixed one
 const s3BucketUrl = process.env.S3_PUBLIC_SCHEMA_URL ? process.env.S3_PUBLIC_SCHEMA_URL : 'http://dev-schemas.civic.com.s3-website-us-east-1.amazonaws.com';
 
@@ -36,7 +37,9 @@ describe.skip('Public Schemas Integration Test Suite', () => {
       }
     };
     const promises = [];
-    credentialDefinitions.forEach((credentialDefinition) => { promises.push(validateSchemaJestStep(credentialDefinition)); });
+    credentialDefinitions.forEach((credentialDefinition) => {
+      promises.push(validateSchemaJestStep(credentialDefinition));
+    });
     Promise.all(promises).then((values) => {
       values.forEach(isValid => expect(isValid).toBeTruthy());
       done();
@@ -71,7 +74,9 @@ describe.skip('Public Schemas Integration Test Suite', () => {
       }
     };
     const promises = [];
-    credentialDefinitions.forEach((credentialDefinition) => { promises.push(validateSchemaJestStep(credentialDefinition)); });
+    credentialDefinitions.forEach((credentialDefinition) => {
+      promises.push(validateSchemaJestStep(credentialDefinition));
+    });
     Promise.all(promises).then((values) => {
       values.forEach(isValid => expect(isValid).toBeFalsy());
       done();

--- a/__integrations__/schemas/PublicSchemasValidation.test.js
+++ b/__integrations__/schemas/PublicSchemasValidation.test.js
@@ -84,7 +84,7 @@ describe.skip('Public Schemas Integration Test Suite', () => {
     // iterate all over the credential's definitions
     const validateSchemaJestStep = async (definition) => {
       const jsonFolderVersion = `${definition.version}`;
-      const identifier = definition.identifier;
+      const { identifier } = definition;
       const typeFolder = identifier.substring(identifier.indexOf(':') + 1, identifier.lastIndexOf(':'));
       const jsonFolder = `${fixturesPath}/correct/${typeFolder}`;
       // the file name is the last part of the identifier

--- a/__integrations__/schemas/PublicSchemasValidation.test.js
+++ b/__integrations__/schemas/PublicSchemasValidation.test.js
@@ -9,7 +9,9 @@ const fixturesPath = '__integrations__/fixtures';
 // testings is done only on the test bucket,
 // since we only release to production on manual CircleCI flow
 // check process env for S3 SChema URL or fallback to an fixed one
-const s3BucketUrl = process.env.S3_PUBLIC_SCHEMA_URL ? process.env.S3_PUBLIC_SCHEMA_URL : 'http://dev-schemas.civic.com.s3-website-us-east-1.amazonaws.com';
+const s3BucketUrl = process.env.S3_PUBLIC_SCHEMA_URL
+  ? process.env.S3_PUBLIC_SCHEMA_URL
+  : 'http://dev-schemas.civic.com.s3-website-us-east-1.amazonaws.com';
 
 describe.skip('Public Schemas Integration Test Suite', () => {
   it('Should succeed validation from the from the correct json file in Credential folder', async (done) => {
@@ -18,7 +20,9 @@ describe.skip('Public Schemas Integration Test Suite', () => {
     const validateSchemaJestStep = async (credentialDefinition) => {
       const jsonFolderVersion = `${credentialDefinition.version}`;
       // the file name is the last part of the identifier
-      const jsonFileName = credentialDefinition.identifier.substring(credentialDefinition.identifier.lastIndexOf(':') + 1);
+      const jsonFileName = credentialDefinition.identifier.substring(
+        credentialDefinition.identifier.lastIndexOf(':') + 1,
+      );
       // all fixtures are json
       const jsonFile = `${jsonFileName}.json`;
       // read the generated json
@@ -54,7 +58,9 @@ describe.skip('Public Schemas Integration Test Suite', () => {
     const validateSchemaJestStep = async (credentialDefinition) => {
       const jsonFolderVersion = `${credentialDefinition.version}`;
       // the file name is the last part of the identifier
-      const jsonFileName = credentialDefinition.identifier.substring(credentialDefinition.identifier.lastIndexOf(':') + 1);
+      const jsonFileName = credentialDefinition.identifier.substring(
+        credentialDefinition.identifier.lastIndexOf(':') + 1,
+      );
       // all fixtures are json
       const jsonFile = `${jsonFileName}.json`;
       // read the generated json

--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -38,7 +38,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   // This test was skiped cause in the current definitions we don't have this case any more
-  test.skip('should validate new defined credentials with the obligatory Meta:expirationDate UCA with null value', () => {
+  test.skip('should validate new defined credentials with the required Meta:expirationDate UCA with null value', () => {
     const name = new UCA.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
     const dob = new UCA.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('cvc:Credential:Identity', uuidv4(), null, [name, dob], '1');
@@ -222,7 +222,8 @@ describe('Unit tests for Verifiable Credentials', () => {
     expect(filtered.claim.contact.phoneNumber.number).toBe('kCTGifTdom');
   });
 
-  it('Should filter claims for PhoneNumber asking for cvc:Phone:countryCode and return only the claim for country code', () => {
+  it('Should filter claims for PhoneNumber asking for cvc:Phone:countryCode '
+    + 'and return only the claim for country code', () => {
     const value = {
       country: '1ApYikRwDl',
       countryCode: 'U4drpB96Hk',
@@ -251,7 +252,8 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
 
-  test('cred.verify(): with a valid cred without expirationDate, should return at least VERIFY_LEVELS.PROOFS level', () => {
+  test('cred.verify(): with a valid cred without expirationDate, '
+    + 'should return at least VERIFY_LEVELS.PROOFS level', () => {
     const credJSon = require('./fixtures/Cred1.json'); // eslint-disable-line
     const cred = VC.fromJSON(credJSon);
     expect(cred).toBeDefined();

--- a/__test__/creds/VerifiableCredentialSchema.test.js
+++ b/__test__/creds/VerifiableCredentialSchema.test.js
@@ -30,7 +30,9 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
     const validateSchemaJestStep = async (credentialDefinition) => {
       const ucaArray = [];
       credentialDefinition.depends.forEach((ucaDefinitionIdentifier) => {
-        const ucaDefinition = ucaDefinitions.find(ucaDef => ucaDef.identifier === ucaDefinitionIdentifier);
+        const ucaDefinition = ucaDefinitions.find(ucaDef => (
+          ucaDef.identifier === ucaDefinitionIdentifier
+        ));
         const ucaJson = SchemaGenerator.buildSampleJson(ucaDefinition);
         let value = ucaJson;
         if (Object.keys(ucaJson).length === 1) {
@@ -53,7 +55,9 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
       return isValid;
     };
     const promises = [];
-    credentialDefinitions.forEach((credentialDefinition) => { promises.push(validateSchemaJestStep(credentialDefinition)); });
+    credentialDefinitions.forEach((credentialDefinition) => {
+      promises.push(validateSchemaJestStep(credentialDefinition));
+    });
     Promise.all(promises).then((values) => {
       values.forEach(isValid => expect(isValid).toBeTruthy());
       done();
@@ -62,10 +66,14 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
 
   it('Should change the VC Json data and fail against AJV', () => {
     const identifier = 'cvc:Credential:Identity';
-    const credentialDefinition = credentialDefinitions.find(credsDef => credsDef.identifier === identifier);
+    const credentialDefinition = credentialDefinitions.find(credsDef => (
+      credsDef.identifier === identifier
+    ));
     const ucaArray = [];
     credentialDefinition.depends.forEach((ucaDefinitionIdentifier) => {
-      const ucaDefinition = ucaDefinitions.find(ucaDef => ucaDef.identifier === ucaDefinitionIdentifier);
+      const ucaDefinition = ucaDefinitions.find(ucaDef => (
+        ucaDef.identifier === ucaDefinitionIdentifier
+      ));
       const ucaJson = SchemaGenerator.buildSampleJson(ucaDefinition);
       let value = ucaJson;
       if (Object.keys(ucaJson).length === 1) {
@@ -74,7 +82,8 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
       const dependentUca = new UCA(ucaDefinition.identifier, value, ucaDefinition.version);
       ucaArray.push(dependentUca);
     });
-    const credential = new VC(credentialDefinition.identifier, `jest:test:${uuidv1()}`, null, ucaArray, 1);
+    const issuer = `jest:test:${uuidv1()}`;
+    const credential = new VC(credentialDefinition.identifier, issuer, null, ucaArray, 1);
     const jsonString = JSON.stringify(credential, null, 2);
     const generatedJson = JSON.parse(jsonString);
     const jsonSchema = SchemaGenerator.process(credential, generatedJson);
@@ -87,10 +96,14 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
 
   it('Should add an property to the root of the json and fail against AJV additionalProperties', () => {
     const identifier = 'cvc:Credential:Identity';
-    const credentialDefinition = credentialDefinitions.find(credsDef => credsDef.identifier === identifier);
+    const credentialDefinition = credentialDefinitions.find(credsDef => (
+      credsDef.identifier === identifier
+    ));
     const ucaArray = [];
     credentialDefinition.depends.forEach((ucaDefinitionIdentifier) => {
-      const ucaDefinition = ucaDefinitions.find(ucaDef => ucaDef.identifier === ucaDefinitionIdentifier);
+      const ucaDefinition = ucaDefinitions.find(ucaDef => (
+        ucaDef.identifier === ucaDefinitionIdentifier
+      ));
       const ucaJson = SchemaGenerator.buildSampleJson(ucaDefinition);
       let value = ucaJson;
       if (Object.keys(ucaJson).length === 1) {

--- a/__test__/creds/VerifiableCredentialSchema.test.js
+++ b/__test__/creds/VerifiableCredentialSchema.test.js
@@ -34,7 +34,7 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
         const ucaJson = SchemaGenerator.buildSampleJson(ucaDefinition);
         let value = ucaJson;
         if (Object.keys(ucaJson).length === 1) {
-          value = Object.values(ucaJson)[0];
+          [value] = Object.values(ucaJson);
         }
         const dependentUca = new UCA(ucaDefinition.identifier, value, ucaDefinition.version);
         ucaArray.push(dependentUca);
@@ -69,7 +69,7 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
       const ucaJson = SchemaGenerator.buildSampleJson(ucaDefinition);
       let value = ucaJson;
       if (Object.keys(ucaJson).length === 1) {
-        value = Object.values(ucaJson)[0];
+        [value] = Object.values(ucaJson);
       }
       const dependentUca = new UCA(ucaDefinition.identifier, value, ucaDefinition.version);
       ucaArray.push(dependentUca);
@@ -94,7 +94,7 @@ describe('VerifiableCredentials SchemaGenerator validation', () => {
       const ucaJson = SchemaGenerator.buildSampleJson(ucaDefinition);
       let value = ucaJson;
       if (Object.keys(ucaJson).length === 1) {
-        value = Object.values(ucaJson)[0];
+        [value] = Object.values(ucaJson);
       }
       const dependentUca = new UCA(ucaDefinition.identifier, value, ucaDefinition.version);
       ucaArray.push(dependentUca);

--- a/__test__/isClaimRelated.test.js
+++ b/__test__/isClaimRelated.test.js
@@ -1,7 +1,8 @@
 const isClaimRelated = require('../src/isClaimRelated');
 
 describe('isClaimRelated Tests', () => {
-  it('Should validate a claim path against UCA definitions and VC definitions and succeed', (done) => {
+  it('Should validate a claim path against UCA definitions '
+    + 'and VC definitions and succeed', (done) => {
     const uca = 'claim-cvc:Document:name-1';
     const claim = 'document.name.givenNames';
     const credential = 'cvc:Credential:GenericDocumentId';
@@ -10,7 +11,8 @@ describe('isClaimRelated Tests', () => {
     done();
   });
 
-  it('Should validate a claim path against UCA definitions and VC definitions and succeed returning false for an non existent dependency', (done) => {
+  it('Should validate a claim path against UCA definitions and VC definitions and '
+    + 'succeed returning false for an non existent dependency', (done) => {
     const uca = 'claim-cvc:Contact:phoneNumber-1';
     const claim = 'contact.phoneNumber.number';
     const credential = 'cvc:Credential:GenericDocumentId';

--- a/__test__/services/configBranch.test.js
+++ b/__test__/services/configBranch.test.js
@@ -1,4 +1,6 @@
-// do not put these tests on the same file as config.test.js or else jest will fail coverage (describe.beforeEach scope not working)
+// do not put these tests on the same file as config.test.js or else jest will fail coverage
+// (describe.beforeEach scope not working)
+
 describe('Test process platform', () => {
   beforeEach(() => {
     this.originalPlatform = process.platform;

--- a/__test__/uca/UserCollectableAttributes.test.js
+++ b/__test__/uca/UserCollectableAttributes.test.js
@@ -148,7 +148,7 @@ describe('UCA Constructions tests', () => {
   });
 
   test('UCA should Construct with a simple Attestatble Value', () => {
-    const aSingleAttestationValue = 'urn:givenNames:873b59b3c4faa0c63e6ec788041291f36b915357cffaaf6c39661b2a94783d19:Joao';
+    const aSingleAttestationValue = 'urn:givenNames:873b59b3c4faa0c63e6ec788041291f36b915357cffaaf6c39661b2a94783d19:Joao'; // eslint-disable-line
     const v = new UCA.NameGivenNames({ attestableValue: aSingleAttestationValue });
     expect(v).toBeDefined();
     const attValues = v.getAttestableValues();
@@ -172,7 +172,7 @@ describe('UCA Constructions tests', () => {
 
   test('UCA should Construct with a complex Attestatble Value: cvc:Identity:name', () => {
     // eslint-disable-next-line max-len
-    const aComplexAttestableValue = 'urn:givenNames:0b5cbce9f91d64fc413bdc892017324a0cc1e4614e874056ed16cd8e08ac02de:Joao|urn:familyNames:2211b059eaece64918755075026cebd230e5c18ef883f5e68a196815804d2de3:Santos|urn:otherNames:1eab775b23947b2685ba1ecf5ec9333e3210b3aaaee40ce6dc1fc95ef2d6177e:Barbosa|';
+    const aComplexAttestableValue = 'urn:givenNames:0b5cbce9f91d64fc413bdc892017324a0cc1e4614e874056ed16cd8e08ac02de:Joao|urn:familyNames:2211b059eaece64918755075026cebd230e5c18ef883f5e68a196815804d2de3:Santos|urn:otherNames:1eab775b23947b2685ba1ecf5ec9333e3210b3aaaee40ce6dc1fc95ef2d6177e:Barbosa|'; // eslint-disable-line
     const v = new UCA.IdentityName({ attestableValue: aComplexAttestableValue });
     expect(v).toBeDefined();
     const attValues = v.getAttestableValues();
@@ -186,7 +186,7 @@ describe('UCA Constructions tests', () => {
 
   test('UCA should Construct with a complex Attestable Value: IdentityName syntax\'s sugar', () => {
     // eslint-disable-next-line max-len
-    const aComplexAttestableValue = 'urn:givenNames:0b5cbce9f91d64fc413bdc892017324a0cc1e4614e874056ed16cd8e08ac02de:Joao|urn:familyNames:2211b059eaece64918755075026cebd230e5c18ef883f5e68a196815804d2de3:Santos|urn:otherNames:1eab775b23947b2685ba1ecf5ec9333e3210b3aaaee40ce6dc1fc95ef2d6177e:Barbosa|';
+    const aComplexAttestableValue = 'urn:givenNames:0b5cbce9f91d64fc413bdc892017324a0cc1e4614e874056ed16cd8e08ac02de:Joao|urn:familyNames:2211b059eaece64918755075026cebd230e5c18ef883f5e68a196815804d2de3:Santos|urn:otherNames:1eab775b23947b2685ba1ecf5ec9333e3210b3aaaee40ce6dc1fc95ef2d6177e:Barbosa|'; // eslint-disable-line
     const identifier = 'cvc:Identity:name';
     const v = new UCA(identifier, { attestableValue: aComplexAttestableValue });
     expect(v).toBeDefined();
@@ -203,7 +203,7 @@ describe('UCA Constructions tests', () => {
   test('UCA should Construct with a complex Attestatble Value: cvc:Identity:dateOfBirth', () => {
     const identifier = 'cvc:Identity:dateOfBirth';
     // eslint-disable-next-line max-len
-    const aComplexAttestableValue = 'urn:day:bdc52df4b0149beb3d67720e82bfd20e86d31e951bd66daeed8a87f3a998de49:00000020|urn:month:0ff6a4dc3b4e7a0b2cfb3a9f0479dc89d9757736d7e46e31ddb3dc53a9179b56:00000003|urn:year:ec4fcd9bad1839c052d0a23a9fba92eaf35d457e83ae50ea902bf3b5c3b490ad:00001978|';
+    const aComplexAttestableValue = 'urn:day:bdc52df4b0149beb3d67720e82bfd20e86d31e951bd66daeed8a87f3a998de49:00000020|urn:month:0ff6a4dc3b4e7a0b2cfb3a9f0479dc89d9757736d7e46e31ddb3dc53a9179b56:00000003|urn:year:ec4fcd9bad1839c052d0a23a9fba92eaf35d457e83ae50ea902bf3b5c3b490ad:00001978|'; // eslint-disable-line
 
     const v = new UCA(identifier, { attestableValue: aComplexAttestableValue });
     const attestableValue = v.getAttestableValue();
@@ -232,7 +232,7 @@ describe('UCA Constructions tests', () => {
 
   test('Construct a cvc:Meta:expirationDate as a Attestable Value', () => {
     const identifier = 'cvc:Meta:expirationDate';
-    const anAttestationValue = 'urn:expirationDate:9dabdd37eca1bc98bcc725d66c77f10707fa9f3292752a31ad9dd94d17557e81:2018-06-20T13:51:18.640Z';
+    const anAttestationValue = 'urn:expirationDate:9dabdd37eca1bc98bcc725d66c77f10707fa9f3292752a31ad9dd94d17557e81:2018-06-20T13:51:18.640Z'; // eslint-disable-line
     const v = new UCA(identifier, { attestableValue: anAttestationValue });
     expect(v).toBeDefined();
     const attValues = v.getAttestableValues();

--- a/__test__/uca/UserCollectableAttributes.test.js
+++ b/__test__/uca/UserCollectableAttributes.test.js
@@ -1,6 +1,4 @@
-const _ = require('lodash');
 const UCA = require('../../src/uca/UserCollectableAttribute');
-const definitions = require('../../src/uca/definitions');
 
 describe('UCA Constructions tests', () => {
   test('UCA construction should fails', () => {
@@ -246,7 +244,7 @@ describe('UCA Constructions tests', () => {
 
   test('Construct a cvc:Identity.name without one the last property value', () => {
     const identifier = 'cvc:Identity:name';
-    const attestationValue = 'urn:givenNames:9619312ef69e2b417edc1e48f2be8f844f2c3b6b04707060fc9052dff1551c9d:Joao|urn:otherNames:5280dfb5bfcf80469156b68807f280c0db8bf3f8ea4653b41d4c61996cd75afd:Barbosa|';
+    const attestationValue = 'urn:givenNames:9619312ef69e2b417edc1e48f2be8f844f2c3b6b04707060fc9052dff1551c9d:Joao|urn:otherNames:5280dfb5bfcf80469156b68807f280c0db8bf3f8ea4653b41d4c61996cd75afd:Barbosa|'; // eslint-disable-line
     const v = new UCA(identifier, { attestableValue: attestationValue });
     expect(v).toBeDefined();
     expect(v.last).toBeUndefined();

--- a/__test__/uca/UserCollectableAttributesSchemas.test.js
+++ b/__test__/uca/UserCollectableAttributesSchemas.test.js
@@ -1,5 +1,4 @@
 const Ajv = require('ajv');
-const fs = require('fs');
 const SchemaGenerator = require('../../src/schemas/generator/SchemaGenerator');
 const definitions = require('../../src/uca/definitions');
 const UCA = require('../../src/uca/UserCollectableAttribute');

--- a/__test__/uca/UserCollectableAttributesSchemas.test.js
+++ b/__test__/uca/UserCollectableAttributesSchemas.test.js
@@ -21,7 +21,8 @@ describe('UCA Json Sample Date Construction tests', () => {
     done();
   });
 
-  it('Should generate Sample Data from all UCA, create the json schema and use AJV to validate both the data and the json schema against each other', async (done) => {
+  it('Should generate Sample Data from all UCA, create the json schema and use AJV to '
+    + ' validate both the data and the json schema against each other', async (done) => {
     definitions.forEach((definition) => {
       const json = SchemaGenerator.buildSampleJson(definition);
       const jsonSchema = SchemaGenerator.process(definition, json);

--- a/__test__/uca/UserCollectableAttributesSchemasMocks.test.js
+++ b/__test__/uca/UserCollectableAttributesSchemasMocks.test.js
@@ -1,10 +1,10 @@
+const Ajv = require('ajv');
 const SchemaGenerator = require('../../src/schemas/generator/SchemaGenerator');
 const ucaMockDefinitions = require('../../src/uca/__mocks__/definitions');
 
 jest.mock('../../src/uca/definitions');
 
 const UCA = require('../../src/uca/UserCollectableAttribute');
-const Ajv = require('ajv');
 
 /**
  * Jest is really a painful when it comes to mocking require.
@@ -29,4 +29,3 @@ describe('UCA Json Sample Date Construction tests', () => {
     done();
   });
 });
-

--- a/__test__/uca/UserCollectableAttributesSchemasMocks.test.js
+++ b/__test__/uca/UserCollectableAttributesSchemasMocks.test.js
@@ -8,10 +8,11 @@ const UCA = require('../../src/uca/UserCollectableAttribute');
 
 /**
  * Jest is really a painful when it comes to mocking require.
- * I have built this separate file, because to mock require jest.mock has to be called before the require
- * Or you have to configure the module mapper on the package.json
- * That led us to two test classes for the same semantic 'test subject', in this case UCA Schema generations
- * If you mock on the other file it will not work, as UCA constructor really need the definitions in memory
+ * I have built this separate file, because to mock require jest.mock has to be called before
+ * the require or you have to configure the module mapper on the package.json. That led us to
+ * two test classes for the same semantic 'test subject', in this case UCA Schema generations.
+ * If you mock on the other file it will not work, as UCA constructor really need the
+ * definitions in memory.
  */
 describe('UCA Json Sample Date Construction tests', () => {
   it('Testing boolean types on the UCA', async (done) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3107,14 +3107,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3129,20 +3127,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3259,8 +3254,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3272,7 +3266,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3287,7 +3280,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3295,14 +3287,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3321,7 +3311,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3402,8 +3391,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3415,7 +3403,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3537,7 +3524,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "module": "dist/es/index.js",
   "browser": "dist/browser/index.js",
   "scripts": {
-    "lint": "eslint ./src/**.js ./__test__/**.js --max-warnings=0",
+    "lint": "eslint ./src/**/*.js ./__test__/**/*.js --max-warnings=0",
     "test": "cross-env NODE_ENV=false jest",
     "test:watch": "jest --watch",
     "check-schemas": "cross-env NODE_ENV=false jest --no-coverage __integrations__/schemas/",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "module": "dist/es/index.js",
   "browser": "dist/browser/index.js",
   "scripts": {
-    "lint": "eslint ./src/**/*.js ./__test__/**/*.js --max-warnings=0",
+    "lint": "eslint . --max-warnings=0",
+    "lint:fix": "npm run lint -- --fix",
     "test": "cross-env NODE_ENV=false jest",
     "test:watch": "jest --watch",
     "check-schemas": "cross-env NODE_ENV=false jest --no-coverage __integrations__/schemas/",

--- a/src/creds/VerifiableCredential.js
+++ b/src/creds/VerifiableCredential.js
@@ -43,7 +43,7 @@ function getClaimsWithFlatKeys(claims) {
 
 
 function paths(root) {
-  const paths = [];
+  const pathList = [];
   const nodes = [{
     obj: root,
     path: [],
@@ -53,7 +53,7 @@ function paths(root) {
     Object.keys(n.obj).forEach((k) => {
       if (typeof n.obj[k] === 'object') {
         const path = n.path.concat(k);
-        paths.push(path);
+        pathList.push(path);
         nodes.unshift({
           obj: n.obj[k],
           path,
@@ -62,7 +62,7 @@ function paths(root) {
     });
   }
   const returnArray = [];
-  paths.forEach((arr) => {
+  pathList.forEach((arr) => {
     returnArray.push(arr.join('.'));
   });
   return returnArray;
@@ -505,6 +505,7 @@ VerifiableCredentialBaseConstructor.fromJSON = (verifiableCredentialJSON) => {
  */
 VerifiableCredentialBaseConstructor.getAllProperties = (identifier) => {
   const vcDefinition = _.find(definitions, { identifier });
+  let properties;
   if (vcDefinition) {
     const allProperties = [];
     _.forEach(vcDefinition.depends, (ucaIdentifier) => {
@@ -514,8 +515,9 @@ VerifiableCredentialBaseConstructor.getAllProperties = (identifier) => {
     _.forEach(vcDefinition.excludes, (ucaIdentifier) => {
       excludesProperties.push(...UCA.getAllProperties(ucaIdentifier));
     });
-    return _.difference(allProperties, excludesProperties);
+    properties = _.difference(allProperties, excludesProperties);
   }
+  return properties;
 };
 
 VerifiableCredentialBaseConstructor.VERIFY_LEVELS = VERIFY_LEVELS;

--- a/src/isClaimRelated.js
+++ b/src/isClaimRelated.js
@@ -3,7 +3,8 @@ const ucaDefinitions = require('./uca/definitions');
 const vcDefinitions = require('./creds/definitions');
 const UCA = require('./uca/UserCollectableAttribute');
 /**
- * Validate an claim path against it's parent UCA, and the parent UCA against the dependencies of an Credential
+ * Validate an claim path against it's parent UCA, and the parent UCA against the
+ * dependencies of an Credential
  * @param claim path, eg: name.first
  * @param uca the global identifier for the UCA/Claim, eg: claim-civ:Identity:name-1
  * @param credential the parent identifier, eg: civ:Credential:GenericId
@@ -22,7 +23,9 @@ function isClaimRelated(claim, uca, credential) {
     if (_.includes(ucaProperties, claim)) {
       // we now have the composite uca, the uca for the claim property, they both are correct
       // we need to check now the UCA is inside the dependencies of the credential refered as parent
-      const credentialDefinition = vcDefinitions.find(definition => definition.identifier === credential);
+      const credentialDefinition = vcDefinitions.find(definition => (
+        definition.identifier === credential
+      ));
       if (credentialDefinition) {
         return _.includes(credentialDefinition.depends, ucaIdentifier);
       }

--- a/src/schemas/generator/SchemaGenerator.js
+++ b/src/schemas/generator/SchemaGenerator.js
@@ -161,14 +161,18 @@ const generateRandomNumberValueWithRange = (definition) => {
   if (definition !== null) {
     /*
      * 6.2.5. exclusiveMinimum
-     * The value of "exclusiveMinimum" MUST be number, representing an exclusive lower limit for a numeric instance.
-     * If the instance is a number, then the instance is valid only if it has a value strictly greater than (not equal to) "exclusiveMinimum".
+     * The value of "exclusiveMinimum" MUST be number, representing an exclusive
+     * lower limit for a numeric instance. If the instance is a number, then the
+     * instance is valid only if it has a value strictly greater than (not equal
+     * to) "exclusiveMinimum".
      */
     const exclusiveMinVariance = definition.exclusiveMinimum ? 1 : 0;
     /*
      * 6.2.3. exclusiveMaximum
-     * The value of "exclusiveMaximum" MUST be number, representing an exclusive upper limit for a numeric instance.
-     * If the instance is a number, then the instance is valid only if it has a value strictly less than (not equal to) "exclusiveMaximum".
+     * The value of "exclusiveMaximum" MUST be number, representing an exclusive
+     * upper limit for a numeric instance. If the instance is a number, then the
+     * instance is valid only if it has a value strictly less than (not equal to)
+     * "exclusiveMaximum".
      */
     const exclusiveMaxVariance = definition.exclusiveMaximum ? -1 : 0;
     if (typeof definition.minimum !== 'undefined' && definition.minimum !== null
@@ -180,7 +184,9 @@ const generateRandomNumberValueWithRange = (definition) => {
       genRandomNumber = definition.minimum + (Math.random() * definition.maximum);
     } else if (typeof definition.minimum !== 'undefined' && definition.minimum !== null) {
       if (Number.isInteger(definition.minimum)) {
-        genRandomNumber = Math.floor(definition.minimum + exclusiveMinVariance + (Math.random() * 100));
+        genRandomNumber = Math.floor(
+          definition.minimum + exclusiveMinVariance + (Math.random() * 100),
+        );
       }
       genRandomNumber = definition.minimum + (Math.random() * 100);
     } else if (typeof definition.maximum !== 'undefined' && definition.maximum !== null) {

--- a/src/services/DummyAnchorServiceImpl.js
+++ b/src/services/DummyAnchorServiceImpl.js
@@ -1,3 +1,5 @@
+/* eslint no-unused-vars: ["error", { "args": "none" }] */
+
 /**
  * Current Anchor/Attester service
  *
@@ -72,34 +74,26 @@ function DummyAnchorServiceImpl(config, http) {
     return Promise.resolve(tempAnchor);
   };
 
-  this.verifySignature = (signature) => {
-    return true;
-  };
+  this.verifySignature = signature => true;
 
   /**
    * This method checks if the subject signature matches the pub key
    * @param subject a json with label, data, signature, pub
    * @returns {*} true or false for the validation
    */
-  this.verifySubjectSignature = (subject) => {
-    return true;
-  };
+  this.verifySubjectSignature = subject => true;
 
   /**
    * This method checks that the attestation / anchor exists on the BC
    */
-  this.verifyAttestation = async (signature) => {
-    return true;
-  };
+  this.verifyAttestation = async signature => true;
 
   this.revokeAttestation = async (signature) => {
     signature.revoked = true; // eslint-disable-line
     return Promise.resolve(signature);
   };
 
-  this.isRevoked = (signature) => {
-    return signature.revoked ? signature.revoked : false;
-  };
+  this.isRevoked = signature => (signature.revoked ? signature.revoked : false);
 
   return this;
 }

--- a/src/services/__mocks__/httpService.js
+++ b/src/services/__mocks__/httpService.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+
 const _ = require('lodash');
 const logger = require('../../logger');
 
@@ -69,7 +71,7 @@ function HttpServiceConstructor() {
 
 logger.debug('Using Mock HTTP Service');
 const http = new HttpServiceConstructor();
-http.request('/status').then(console.log);
+http.request('/status').then(console.log); // eslint-disable-line
 logger.debug(`HTTP Service instance ${JSON.stringify(http, null, 2)}`);
 
 module.exports = http;

--- a/src/services/__mocks__/httpService.js
+++ b/src/services/__mocks__/httpService.js
@@ -1,5 +1,5 @@
-const logger = require('../../logger');
 const _ = require('lodash');
+const logger = require('../../logger');
 
 function HttpServiceConstructor() {
   this.name = 'mockHttp';
@@ -10,10 +10,12 @@ function HttpServiceConstructor() {
     const responses = [
       {
         path: '/registry',
-        response: { clientID: '6e0ce9b31eb13064a194c1482ed3d9d330f22df6fb4cbcc0dbebf3169dc2325b',
+        response: {
+          clientID: '6e0ce9b31eb13064a194c1482ed3d9d330f22df6fb4cbcc0dbebf3169dc2325b',
           xpub: '0469919359510a703516503299c77ef0e00f18255a32db19a3e69636e203f25f29be24b685df9f8a70548751f53a2e4c235ec0fbdc82d0783bd30e315ebfd6bd1e',
           cas: '{"iv":"TEtgZuJdyJFkgcuHoBC52w==","v":1,"iter":10000,"ks":128,"ts":64,"mode":"gcm","adata":"","cipher":"aes","salt":"SA0z5h6IlfA=","ct":"8h6ys3fD31HsWH3s5rrbF6o54ekJf6owhSJBW6FBIhkftJWSWVWVEt0u0FJFqhCqPaEl+DMM6olH9fAcB7bD7i2DRPjLYiC+"}',
-          sak: {} },
+          sak: {},
+        },
       },
       {
         path: '/jwt',

--- a/src/services/anchorService.js
+++ b/src/services/anchorService.js
@@ -1,7 +1,7 @@
 /**
  * Abstract Anchor/Attestation service
- * 
- * @param {*} impl 
+ *
+ * @param {*} impl
  */
 function Anchor(impl) {
   this.impl = impl;

--- a/src/uca/UserCollectableAttribute.js
+++ b/src/uca/UserCollectableAttribute.js
@@ -224,14 +224,16 @@ function UCABaseConstructor(identifier, value, version) {
 
   this.getAttestableValue = () => {
     // all UCA properties they have the form of :propertyName or :something.propertyName
-    const startIndexForPropertyName = this.identifier.includes('.') ? this.identifier.lastIndexOf('.') : this.identifier.lastIndexOf(':');
+    const startIndexForPropertyName = this.identifier.includes('.')
+      ? this.identifier.lastIndexOf('.') : this.identifier.lastIndexOf(':');
     const propertyName = this.identifier.substring(startIndexForPropertyName + 1);
     // it was defined that the attestable value would be on the URN type https://tools.ietf.org/html/rfc8141
     switch (this.type) {
       case 'String':
         return `urn:${propertyName}:${this.salt}:${this.value}`;
       case 'Number':
-        return `urn:${propertyName}:${this.salt}:${_.padStart(this.value.toString(), 8, '0')}`; // TODO @jpsantosbh why did you pad this value?
+        // TODO @jpsantosbh why did you pad this value?
+        return `urn:${propertyName}:${this.salt}:${_.padStart(this.value.toString(), 8, '0')}`;
       case 'Boolean':
         return `urn:${propertyName}:${this.salt}:${this.value}`;
       default:

--- a/src/uca/UserCollectableAttribute.js
+++ b/src/uca/UserCollectableAttribute.js
@@ -318,7 +318,7 @@ function convertIdentifierToClassName(identifier) {
 _.forEach(_.filter(definitions, d => d.credentialItem), (def) => {
   const name = convertIdentifierToClassName(def.identifier);
   const source = {};
-  const identifier = def.identifier;
+  const { identifier } = def;
 
   function UCAConstructor(value, version) {
     const self = new UCABaseConstructor(identifier, value, version);

--- a/src/uca/UserCollectableAttribute.js
+++ b/src/uca/UserCollectableAttribute.js
@@ -34,9 +34,9 @@ function isValid(value, type, definition) {
         && (definition.maximumLength ? value.length <= definition.minimumLength : true);
     case 'Number':
       return ((!_.isNil(definition.minimum)
-        && definition.exclusiveMinimum ? value > definition.minimum : value >= definition.minimum) || _.isNil(definition.minimum))
+        && definition.exclusiveMinimum ? value > definition.minimum : value >= definition.minimum) || _.isNil(definition.minimum)) // eslint-disable-line
         && ((!_.isNil(definition.maximum)
-        && definition.exclusiveMaximum ? value < definition.maximum : value <= definition.maximum) || _.isNil(definition.maximum));
+        && definition.exclusiveMaximum ? value < definition.maximum : value <= definition.maximum) || _.isNil(definition.maximum)); // eslint-disable-line
     case 'Boolean':
       return _.isBoolean(value);
     default:
@@ -164,7 +164,9 @@ function UCABaseConstructor(identifier, value, version) {
 
 
   this.identifier = identifier;
-  const definition = version ? _.find(definitions, { identifier, version }) : _.find(definitions, { identifier });
+  const definition = version
+    ? _.find(definitions, { identifier, version })
+    : _.find(definitions, { identifier });
   this.version = version || definition.version;
 
   this.type = getTypeName(definition);
@@ -184,8 +186,12 @@ function UCABaseConstructor(identifier, value, version) {
       for (let i = 0; i < parsedAttestableValue.length; i += 1) {
         const { propertyName } = parsedAttestableValue[i];
         // we have stored only the property name on the urn, so we have to find the UCA definition
-        const filteredIdentifier = definition.type.properties.find(property => property.type.endsWith(propertyName)).type;
-        ucaValue[propertyName] = new UCABaseConstructor(filteredIdentifier, { attestableValue: parsedAttestableValue[i].stringValue });
+        const filteredIdentifier = definition.type.properties.find(property => (
+          property.type.endsWith(propertyName)
+        )).type;
+        ucaValue[propertyName] = new UCABaseConstructor(
+          filteredIdentifier, { attestableValue: parsedAttestableValue[i].stringValue },
+        );
       }
       // console.log(ucaValue);
       this.value = ucaValue;
@@ -202,7 +208,9 @@ function UCABaseConstructor(identifier, value, version) {
   } else if (_.isEmpty(definition.type.properties)) {
     throw new Error(`${JSON.stringify(value)} is not valid for ${identifier}`);
   } else {
-    const hasRequireds = _.reduce(definition.type.required, (has, required) => value[required] && has, true);
+    const hasRequireds = _.reduce(
+      definition.type.required, (has, required) => value[required] && has, true,
+    );
     if (!hasRequireds) {
       throw new Error(`Missing required fields to ${identifier}`);
     }


### PR DESCRIPTION
Fix lint command to check folders recursively.

Proposed changes:
- Make lint command generic: `eslint .`, instead of specifying each folder to be checked. A `.eslintignore` file was added for files/folders to be ignored. 
- Add `lint:fix` command (fix simple lint errors)
- Change `max-len` rule to warn when line is longer than 120 characters (it was 200).
- Fix lint errors