### PR TITLE
Improving release process - creating 'Github releases'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+-release.*$/
+              only: /^release\..*$/
             branches:
               ignore: /.*/
       - release:
@@ -25,7 +25,7 @@ workflows:
             - build
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+-release.*$/
+              only: /^release\..*$/
             branches:
               ignore: /.*/
   deploy-npm:
@@ -77,6 +77,9 @@ jobs:
 
   release:
     <<: *defaults
+    environment:
+      HUB_ARTIFACT_VERSION: 2.5.1
+      HUB_ARTIFACT: hub-linux-amd64-2.5.1
     steps:
       - checkout
 
@@ -86,6 +89,10 @@ jobs:
           - v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
 
       - run: sudo npm install -g npm
+      - run: |
+          sh ./.circleci/install_hub.sh
+          mkdir ~/.config/ && echo -e "github.com:\n- user: civictechuser\n  oauth_token: $GITHUB_API_KEY\n  protocol: https\n" > ~/.config/hub
+
       - run: npm ci
 
       - save_cache:
@@ -108,11 +115,15 @@ jobs:
             git config --global push.default simple
 
       - run:
-          name: tag
-          command: npm run tag
+          name: create-release
+          command: npm run release:create
+
       - run:
           name: delete-release-tag
           command: git push --delete origin $CIRCLE_TAG
+
+      - run: |
+          hub release delete $CIRCLE_TAG
   deploy:
     <<: *defaults  
     steps:

--- a/.circleci/install_hub.sh
+++ b/.circleci/install_hub.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+mkdir -p .hub_tmp
+cd .hub_tmp
+
+if [ ! -f "$HUB_ARTIFACT.tgz" ]; then
+    wget https://github.com/github/hub/releases/download/v$HUB_ARTIFACT_VERSION/$HUB_ARTIFACT.tgz
+fi
+
+tar -xvzf $HUB_ARTIFACT.tgz
+sudo ./$HUB_ARTIFACT/install
+
+rm -rf ./$HUB_ARTIFACT

--- a/README.md
+++ b/README.md
@@ -693,12 +693,13 @@ This is used on this library on src/services/config.js
 
 ## Releases
 
-The release process is fully automated and started by Civic members when it's created a tag on Github following the pattern vX.X.X-releaseX. E.g.: v0.2.29-release1.
+The release process is fully automated and started by Civic members when it's created a tag on Github following the pattern ^release\\..*$. E.g.: `release.1`.
 
 After the creation of the tag, Circle Ci will trigger a job to:
 
 build source files
 run unit tests
 increase version number on package.json
-create the stable version tag dropping the 'release' suffix. E.g: v0.2.29
+create the stable version and tag it. E.g: v0.2.29
+remove the release.N tag
 deploy the binary file to NPM

--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "build:browser:clean": "rimraf dist/prebrowser",
     "build:browser": "npm run build:browser:before && npm run build:browser:after && npm run build:browser:clean",
     "build": "npm run build:browser && npm run build:cjs && npm run build:es",
-    "postversion": "git checkout master && git add --all && git commit -m\"build and version $npm_package_version\" -m\"[skip ci]\" && git push origin master",
     "pretag": "git fetch --tags",
     "tag": "git tag v$npm_package_version && git push --tags origin master",
-    "precommit": "npm run lint"
+    "precommit": "npm run lint",
+    "release:create": "hub release create -m v$npm_package_version v$npm_package_version"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
- Removing the 'Github release' that is created to trigger the release process
- Removing postversion hook because versions are now manually defined
- Triggering release process when a tag following the pattern '^release..*$' is created
- Instead of creating release tags this PR creates 'Github releases' at the end of the release process.