### PR TITLE
Feature/cvc 1163  add shared idv error classes to the credential commons library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3299,12 +3299,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3319,17 +3321,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3446,7 +3451,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3458,6 +3464,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3472,6 +3479,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3479,12 +3487,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3503,6 +3513,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3583,7 +3594,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3595,6 +3607,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3716,6 +3729,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "author": "Identity.com Community",
   "license": "MIT",
   "description": "Verifiable Credential and Attestation Library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.0",
   "author": "Identity.com Community",
   "license": "MIT",
   "description": "Verifiable Credential and Attestation Library",

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -19,6 +19,7 @@ const IDVErrorCodes = {
   ERROR_IDV_UCA_BAD_VALUE: 'error.idv.uca.bad.value',
   ERROR_IDV_UCA_UPDATE_NO_STATUS: 'error.idv.uca.update.no.status',
   ERROR_IDV_UCA_UPDATE_NO_PROCESS_STATUS: 'error.idv.uca.update.no.process.status',
+  ERROR_IDV_TOKEN_RECEIVED_BEFORE_ISSUE: 'error.idv.token.received.before.issue',
 };
 
 // these are used in the 'name' property in the array of objects passed as the errorContext

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -22,20 +22,19 @@ const ErrorContextTypes = {
 
 /*
 * IDVError parses a HTTP Error response body from the IDV-toolkit
-* expected errorObj properties:
-* message: human readable explanation of the error e.g. 'Missing required UCA fields'
-* name: Error-Code, defined in IDVErrorCodes, e.g. IDVErrorCodes.ERROR_IDV_UCA_MISSING_PROPERTY
-* code: HTTP code. Will mostly be 400 or 500
-* data: an array of objects with { name: "name", value: "value" } properties e.g.
-* [{ name: ErrorContextType.MISSING_PROPERTY, value: missingProperty }]
 * Usage: the IDVError can be instantiated directly from the HTTPResponse body e.g.
 * const idvError = new IDVError(response.body);
+* @param  errorObj: parsed directly from the HTTP Response body which should contain
+*           message: human readable explanation of the error e.g. 'Missing required UCA fields'
+*           name: Error-Code, defined in IDVErrorCodes, e.g. IDVErrorCodes.ERROR_IDV_UCA_MISSING_PROPERTY
+*           data: an array of objects with { name: "name", value: "value" } properties e.g.
+*               [{ name: ErrorContextType.MISSING_PROPERTY, value: missingProperty }]
+* @returns an instance of IDVError
 * */
 class IDVError {
   constructor(errorObj) {
     this.message = errorObj.message;
     this.errorCode = errorObj.name;
-    this.code = errorObj.code;
     this.errorContext = errorObj.data;
   }
 }

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -28,7 +28,7 @@ const ErrorContextTypes = {
   UCA_STATE: 'uca_state',
   UCA_VALUE: 'uca_value',
   UCA_VERSION: 'uca_version',
-  EXPECTED_UCA_VERSION: 'expected_uca_version',
+  PLAN_UCA_VERSION: 'plan_uca_version',
   PROCESS_ID: 'process_id',
   UCA_NAME: 'uca_name',
   UCA_ID: 'uca_id',

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -20,11 +20,17 @@ const ErrorContextTypes = {
   PROCESS_STATE: 'process_state',
 };
 
-// message: human readable explanation of the error e.g. 'Missing required UCA fields'
-// name: Error-Code, defined in IDVErrorCodes, e.g. IDVErrorCodes.ERROR_IDV_UCA_MISSING_PROPERTY
-// code: HTTP code. Will mostly be 400 or 500
-// data: an array of objects with { name: "name", value: "value" } properties e.g.
-// [{ name: ErrorContextType.MISSING_PROPERTY, value: missingProperty }]
+/*
+* IDVError parses a HTTP Error response body from the IDV-toolkit
+* expected errorObj properties:
+* message: human readable explanation of the error e.g. 'Missing required UCA fields'
+* name: Error-Code, defined in IDVErrorCodes, e.g. IDVErrorCodes.ERROR_IDV_UCA_MISSING_PROPERTY
+* code: HTTP code. Will mostly be 400 or 500
+* data: an array of objects with { name: "name", value: "value" } properties e.g.
+* [{ name: ErrorContextType.MISSING_PROPERTY, value: missingProperty }]
+* Usage: the IDVError can be instantiated directly from the HTTPResponse body e.g.
+* const idvError = new IDVError(response.body);
+* */
 class IDVError {
   constructor(errorObj) {
     this.message = errorObj.message;

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -32,6 +32,7 @@ const ErrorContextTypes = {
   PROCESS_ID: 'process_id',
   UCA_NAME: 'uca_name',
   UCA_ID: 'uca_id',
+  CREDENTIAL_ITEM: 'credential_item',
 };
 
 /*

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -33,6 +33,7 @@ const ErrorContextTypes = {
   UCA_NAME: 'uca_name',
   UCA_ID: 'uca_id',
   CREDENTIAL_ITEM: 'credential_item',
+  UCA_ERROR: 'uca_error',
 };
 
 /*

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -55,7 +55,7 @@ class IDVError {
   }
 }
 
-module.export = {
+module.exports = {
   IDVErrorCodes,
   ErrorContextTypes,
   IDVError,

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -11,13 +11,24 @@ const IDVErrorCodes = {
   ERROR_IDV_CR_ALREADY_SIGNED: 'error.idv.cr.already.signed',
   ERROR_IDV_CR_MISSING_PROPERTY: 'error.idv.cr.missing.property',
   ERROR_IDV_UCA_SERVER: 'error.idv.uca.server',
+  ERROR_IDV_MISSING_UCA: 'error.idv.missing.uca',
+  ERROR_IDV_UCA_WRONG_VERSION: 'error.idv.uca.wrong.version',
+  ERROR_IDV_UCA_INVALID_EVENT: 'error.idv.uca.invalid.event',
+  ERROR_IDV_MISSING_PROCESS: 'error.idv.missing.process',
+  ERROR_IDV_MISSING_PLAN: 'error.idv.missing.plan',
+  ERROR_IDV_UCA_BAD_VALUE: 'error.idv.uca.bad.value',
 };
 
 // these are used in the 'name' property in the array of objects passed as the errorContext
 const ErrorContextTypes = {
   MISSING_PROPERTY: 'missing_property',
   UCA_STATE: 'uca_state',
+  UCA_VALUE: 'uca_value',
   PROCESS_STATE: 'process_state',
+  UCA_VERSION: 'uca_version',
+  EXPECTED_UCA_VERSION: 'expected_uca_version',
+  PROCESS_ID: 'process_id',
+  UCA_NAME: 'uca_name',
 };
 
 /*

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -1,0 +1,41 @@
+// These codes are passed in the 'name' value of the error object when the IDV-toolkit
+// throws an error
+const IDVErrorCodes = {
+  ERROR_IDV_UCA_MISSING_PROPERTY: 'error.idv.uca.missing.property',
+  ERROR_IDV_UCA_NO_RETRIES: 'error.idv.uca.no.retries',
+  ERROR_IDV_PROCESS_HAS_FINAL_STATUS: 'error.idv.process.has.final.status',
+  ERROR_IDV_UCA_HAS_FINAL_STATUS: 'error.idv.uca.has.final.status',
+  ERROR_IDV_UCA_BATCH_HAS_FINAL_STATUS: 'error.idv.uca.batch.has.final.status',
+  ERROR_IDV_CR_INVALID_CREDENTIAL_ITEM: 'error.idv.cr.invalid.credentialItem',
+  ERROR_IDV_CREDENTIAL_INVALID_SIGNATURE: 'error.idv.credential.invalid.signature',
+  ERROR_IDV_CR_ALREADY_SIGNED: 'error.idv.cr.already.signed',
+  ERROR_IDV_CR_MISSING_PROPERTY: 'error.idv.cr.missing.property',
+  ERROR_IDV_UCA_SERVER: 'error.idv.uca.server',
+};
+
+// these are used in the 'name' property in the array of objects passed as the errorContext
+const ErrorContextTypes = {
+  MISSING_PROPERTY: 'missing_property',
+  UCA_STATE: 'uca_state',
+  PROCESS_STATE: 'process_state',
+};
+
+// message: human readable explanation of the error e.g. 'Missing required UCA fields'
+// name: Error-Code, defined in IDVErrorCodes, e.g. IDVErrorCodes.ERROR_IDV_UCA_MISSING_PROPERTY
+// code: HTTP code. Will mostly be 400 or 500
+// data: an array of objects with { name: "name", value: "value" } properties e.g.
+// [{ name: ErrorContextType.MISSING_PROPERTY, value: missingProperty }]
+class IDVError {
+  constructor(errorObj) {
+    this.message = errorObj.message;
+    this.errorCode = errorObj.name;
+    this.code = errorObj.code;
+    this.errorContext = errorObj.data;
+  }
+}
+
+module.export = {
+  IDVErrorCodes,
+  ErrorContextTypes,
+  IDVError,
+};

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -17,6 +17,8 @@ const IDVErrorCodes = {
   ERROR_IDV_MISSING_PROCESS: 'error.idv.missing.process',
   ERROR_IDV_MISSING_PLAN: 'error.idv.missing.plan',
   ERROR_IDV_UCA_BAD_VALUE: 'error.idv.uca.bad.value',
+  ERROR_IDV_UCA_UPDATE_NO_STATUS: 'error.idv.uca.update.no.status',
+  ERROR_IDV_UCA_UPDATE_NO_PROCESS_STATUS: 'error.idv.uca.update.no.process.status',
 };
 
 // these are used in the 'name' property in the array of objects passed as the errorContext
@@ -29,6 +31,7 @@ const ErrorContextTypes = {
   EXPECTED_UCA_VERSION: 'expected_uca_version',
   PROCESS_ID: 'process_id',
   UCA_NAME: 'uca_name',
+  UCA_ID: 'uca_id',
 };
 
 /*

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -32,6 +32,7 @@ const ErrorContextTypes = {
   PROCESS_ID: 'process_id',
   UCA_NAME: 'uca_name',
   UCA_ID: 'uca_id',
+  UCA: 'uca',
   CREDENTIAL_ITEM: 'credential_item',
 };
 

--- a/src/errors/idvErrors.js
+++ b/src/errors/idvErrors.js
@@ -27,13 +27,11 @@ const ErrorContextTypes = {
   MISSING_PROPERTY: 'missing_property',
   UCA_STATE: 'uca_state',
   UCA_VALUE: 'uca_value',
-  PROCESS_STATE: 'process_state',
   UCA_VERSION: 'uca_version',
   EXPECTED_UCA_VERSION: 'expected_uca_version',
   PROCESS_ID: 'process_id',
   UCA_NAME: 'uca_name',
   UCA_ID: 'uca_id',
-  UCA: 'uca',
   CREDENTIAL_ITEM: 'credential_item',
 };
 

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -1,0 +1,5 @@
+const idvErrors = require('./idvErrors');
+
+module.exports = {
+  idvErrors,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ const VC = require('./creds/VerifiableCredential');
 const { initServices, services } = require('./services/index');
 const isValidGlobalIdentifier = require('./isValidGlobalIdentifier');
 const isClaimRelated = require('./isClaimRelated');
+const errors = require('./errors');
+
 /**
  * Entry Point for Civic Credential Commons
  * @returns {CredentialCommons}
@@ -15,6 +17,7 @@ function CredentialCommons() {
   this.isValidGlobalIdentifier = isValidGlobalIdentifier;
   this.isClaimRelated = isClaimRelated;
   this.services = services;
+  this.errors = errors;
   return this;
 }
 


### PR DESCRIPTION
The credential-wallet (CW) needs a way to get more detailed errors back from the IDV-toolkit. The idvErrors module contains the definitions for the error details that will be sent from the IDV-toolkit when an error is thrown.
The CW will parse a HTTP error response.body returned by the IDV-toolkit by instantiating an IDVError object like:
`const idvError = new IDVError(response.body);`
the idvError.errorCode and idvError.errorContext can then be used to create custom messages/responses to be passed to the frontend/user
