### PR TITLE
added initial HeaderType externalId definition

### DIFF
--- a/src/constants/headers.js
+++ b/src/constants/headers.js
@@ -1,0 +1,6 @@
+const HeaderType = {
+  EXTERNAL_ID_HEADER: 'X-External-ID',
+};
+module.exports = {
+  HeaderType,
+};

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,5 @@
+const headers = require('./headers');
+
+module.exports = {
+  headers,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const { initServices, services } = require('./services/index');
 const isValidGlobalIdentifier = require('./isValidGlobalIdentifier');
 const isClaimRelated = require('./isClaimRelated');
 const errors = require('./errors');
-
+const headers = require('./constants');
 /**
  * Entry Point for Civic Credential Commons
  * @returns {CredentialCommons}
@@ -18,6 +18,7 @@ function CredentialCommons() {
   this.isClaimRelated = isClaimRelated;
   this.services = services;
   this.errors = errors;
+  this.headers = headers;
   return this;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const { initServices, services } = require('./services/index');
 const isValidGlobalIdentifier = require('./isValidGlobalIdentifier');
 const isClaimRelated = require('./isClaimRelated');
 const errors = require('./errors');
-const headers = require('./constants');
+const constants = require('./constants');
 /**
  * Entry Point for Civic Credential Commons
  * @returns {CredentialCommons}
@@ -18,7 +18,7 @@ function CredentialCommons() {
   this.isClaimRelated = isClaimRelated;
   this.services = services;
   this.errors = errors;
-  this.headers = headers;
+  this.constants = constants;
   return this;
 }
 


### PR DESCRIPTION
As agreed at the ExternalId meeting on 04/03/2019, an 'external id' header is required to be added to requests/responses from the Credential Wallet to the IDV-Toolkit. This PR adds the header definition so it can be referenced as a common definition by the CW and IDV-toolkit.

The choice of 'X-External-ID' is to reflect the generic nature of the ID, and appropriate HTTP header naming conventions.