### PR TITLE
CCS-800 - Automate schemas publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,18 @@ workflows:
           context: Development
           requires:
             - build
+          filters:
+            branches:
+              only:
+                - master
       - check-schemas:
           context: Development
           requires:
             - publish-schemas
+          filters:
+            branches:
+              only:
+                - master
 
   build-tag:
     jobs:
@@ -50,6 +58,24 @@ workflows:
           context: Production
           requires:
             - build
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+.*/
+            branches:
+              ignore: /.*/
+      - publish-schemas:
+          context: Production
+          requires:
+            - deploy
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+.*/
+            branches:
+              ignore: /.*/
+      - check-schemas:
+          context: Production
+          requires:
+            - publish-schemas
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ workflows:
   build-and-test:
     jobs:
       - build
-      - publish-schemas
+      - publish-schemas:
           context: Development
       - check-schemas
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ workflows:
   build-and-test:
     jobs:
       - build
+      - publish-schemas
+      - check-schemas
+
   build-tag:
     jobs:
       - build:
@@ -28,6 +31,7 @@ workflows:
               only: /^release\..*$/
             branches:
               ignore: /.*/
+
   deploy-npm:
     jobs:
       - build:
@@ -51,26 +55,20 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
-
       - run: sudo npm install -g npm
       - run: npm ci
-
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
-
       - run:
           name: run tests incl coverage
           command: npm run test
       - run: npm run lint
       - run: npm run build
-
       - persist_to_workspace:
           root: ~/repo
           paths: .
@@ -82,30 +80,23 @@ jobs:
       HUB_ARTIFACT: hub-linux-amd64-2.7.0
     steps:
       - checkout
-
-      # Download and cache dependencies
       - restore_cache:
           keys:
           - v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
-
       - run: sudo npm install -g npm
       - run: |
           sh ./.circleci/install_hub.sh
-          mkdir -p ~/.config/ && echo -e "github.com:\n- user: $GITHUB_USER\n  oauth_token: $GITHUB_API_KEY\n  protocol: https\n" > ~/.config/hub
-
+          mkdir -p ~/.config/ && echo -e "github.com:\n- user: civictechuser\n  oauth_token: $GITHUB_API_KEY\n  protocol: https\n" > ~/.config/hub
       - run: npm ci
-
       - save_cache:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
-
       - run:
           name: run tests incl coverage
           command: npm run test
       - run: npm run lint
       - run: npm run build
-
       - run:
           name: git config
           command: |
@@ -113,15 +104,12 @@ jobs:
             git config user.email "no-reply@civic.com"
             git config user.name "CI Deployer"
             git config --global push.default simple
-
       - run:
           name: create-release
           command: npm run release:create
-
       - run:
           name: delete-release-tag
           command: git push --delete origin $CIRCLE_TAG
-
       - run: |
           hub release delete $CIRCLE_TAG
   deploy:
@@ -135,3 +123,49 @@ jobs:
       - run:
           name: Publish package
           command: npm publish --access=public
+
+  publish-schemas:
+    docker:
+      # image extended from circleci/node:8.9 and includes AWS CLI
+      - image: civicteam/circle-aws-node
+      # environment:
+          #S3_BUCKET_SCHEMA_URL: put your bucket URL here
+          #S3_PUBLIC_SCHEMA_URL: put your public schema URL here
+          #AWS_ACCESS_KEY_ID: put your token here
+          #AWS_SECRET_ACCESS_KEY: put your token here
+    working_directory: ~/repo
+    steps:
+      - checkout:
+          path: ~/repo
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
+      - run: sudo npm install -g npm
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
+      - run: npm run generate-schemas
+      - run: npm run publish-schemas
+
+  check-schemas:
+    docker:
+      # image extended from circleci/node:8.9 and includes AWS CLI
+      - image: civicteam/circle-aws-node
+      # environment:
+          #S3_PUBLIC_SCHEMA_URL: put your public schema URL here
+    working_directory: ~/repo
+    steps:
+      - checkout:
+          path: ~/repo
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
+      - run: sudo npm install -g npm
+      - run: npm install
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}-{{checksum "package-lock.json"}}
+      - run: npm run check-schemas

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ workflows:
     jobs:
       - build
       - publish-schemas
+          context: Development
       - check-schemas
 
   build-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,12 @@ workflows:
       - build
       - publish-schemas:
           context: Development
-      - check-schemas
+          requires:
+            - build
+      - check-schemas:
+          context: Development
+          requires:
+            - publish-schemas
 
   build-tag:
     jobs:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ This Javascript Library provides functionality around Verifiable Credentials (VC
       - [Construting a VerifiableCredential from a JSON](#construting-a-verifiablecredential-from-a-json)
       - [Verifying a Verifiable Credential](#verifying-a-verifiable-credential)
 - [Schema Generator](#schema-generator)
+
 - [Conventions:](#conventions-)
+  * [Publishing schemas](#publishing-schemas)
 - [Commands](#commands)
 - [Integration with CCS Libraries](#integration-with-ccs-libraries)
 - [ES5 and ES6 definitions](#es5-and-es6-definitions)
@@ -626,6 +628,21 @@ The schema generator will generate an json schema like this:
   "additionalProperties": false
 }
 ```
+
+## Publishing schemas
+
+The Verifiable Credential Library has a script, avaiable in the *package.json*, to publish the generate schemas to a bucket in AWS. The following command will publish the schemas:
+```bash
+S3_BUCKET_SCHEMA_URL=<s3://your-bucket-url> npm run publish-schemas
+```
+
+There is also a script to check the published schemas:
+```bash
+S3_PUBLIC_SCHEMA_URL=<http://your-schem-url> npm run check-schemas
+```
+
+To publish and check the schemas it is required to have the environment variables for AWS credentials defined (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).
+
 
 ## Conventions:
 


### PR DESCRIPTION
Update CI configuration to publish schemas as follows:
- publish schemas to dev on every commit in the master
- publish schemas to prod on every new release