### PR TITLE
Fix idDocument definition

### DIFF
--- a/__test__/isValidGlobalIdentifier.test.js
+++ b/__test__/isValidGlobalIdentifier.test.js
@@ -34,4 +34,7 @@ describe('isGlobalIdentifier Tests', () => {
   test('credential-cvc:IDVaaS-v1 is valid', () => {
     expect(isGlobalIdentifier('credential-cvc:IDVaaS-v1')).toBeTruthy();
   });
+  test('credential-cvc:IdDocument-v1 is valid', () => {
+    expect(isGlobalIdentifier('credential-cvc:IdDocument-v1')).toBeTruthy();
+  });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "Identity.com Community",
   "license": "MIT",
   "description": "Verifiable Credential and Attestation Library",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Identity.com Community",
   "license": "MIT",
   "description": "Verifiable Credential and Attestation Library",

--- a/src/creds/definitions.js
+++ b/src/creds/definitions.js
@@ -38,7 +38,7 @@ const definitions = [
     ],
   },
   {
-    identifier: 'credendial-cvc:IdDocument-v1',
+    identifier: 'credential-cvc:IdDocument-v1',
     version: '1',
     depends: [
       'claim-cvc:Document.type-v1',


### PR DESCRIPTION
Fix a typo in the `credential-cvc:IdDocument-v1` definition and update version to `1.0.3`.