### PR TITLE
This fix the credential values comparison inside the `verify` function.

### DIFF
--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -455,11 +455,35 @@ describe('Unit tests for Verifiable Credentials', () => {
     expect(cred.verifyProofs()).toBeTruthy();
   });
 
+  it('Should not verify an VC of with tampered domain Email', () => {
+    const credJSon = require('./fixtures/Email.json'); // eslint-disable-line
+    const cred = VC.fromJSON(credJSon);
+    expect(cred).toBeDefined();
+    cred.claim.contact.email.domain.name = 'civic';
+    expect(cred.verifyProofs()).toBeFalsy();
+  });
+
+  it('Should not verify an VC of with tampered username Email', () => {
+    const credJSon = require('./fixtures/Email.json'); // eslint-disable-line
+    const cred = VC.fromJSON(credJSon);
+    expect(cred).toBeDefined();
+    cred.claim.contact.email.username = 'jpsantos';
+    expect(cred.verifyProofs()).toBeFalsy();
+  });
+
   it('Should verify an VC of type Address', () => {
     const credJSon = require('./fixtures/Address.json'); // eslint-disable-line
     const cred = VC.fromJSON(credJSon);
     expect(cred).toBeDefined();
     expect(cred.verifyProofs()).toBeTruthy();
+  });
+
+  it('Should not verify an VC of tampered Address', () => {
+    const credJSon = require('./fixtures/Address.json'); // eslint-disable-line
+    const cred = VC.fromJSON(credJSon);
+    expect(cred).toBeDefined();
+    cred.claim.identity.address.city = 'Rio de Janeiro';
+    expect(cred.verifyProofs()).toBeFalsy();
   });
 
   it('Should verify an VC of type Identity', () => {
@@ -474,6 +498,16 @@ describe('Unit tests for Verifiable Credentials', () => {
     const cred = VC.fromJSON(credJSon);
     expect(cred).toBeDefined();
     expect(cred.verifyProofs()).toBeTruthy();
+  });
+
+  it('Should not verify an VC of tampered GenericDocumentId', () => {
+    const credJSon = require('./fixtures/GenericDocumentId.json'); // eslint-disable-line
+    const cred = VC.fromJSON(credJSon);
+    expect(cred).toBeDefined();
+    cred.claim.document.dateOfBirth.day = 20;
+    cred.claim.document.dateOfBirth.year = 1900;
+
+    expect(cred.verifyProofs()).toBeFalsy();
   });
 
   it('Should verify an VC of type GenericDocumentId', () => {

--- a/src/creds/VerifiableCredential.js
+++ b/src/creds/VerifiableCredential.js
@@ -77,13 +77,19 @@ function verifyLeave(leave, merkleTools, claims, signature, invalidValues, inval
     }
   } else if (ucaValue.type === 'Object') {
     const ucaValueValue = ucaValue.value;
-    const claimValue = _.get(claims, leave.claimPath);
+    const innerClaimValue = _.get(claims, leave.claimPath);
+    const claimPathSufix = _.last(_.split(leave.claimPath, '.'));
+    const claimValue = {};
+    claimValue[claimPathSufix] = innerClaimValue;
     const ucaValueKeys = _.keys(ucaValue.value);
     _.each(ucaValueKeys, (k) => {
-      const expectedClaimValue = claimValue[k];
-      if (expectedClaimValue && _.get(ucaValueValue[k], 'value') !== expectedClaimValue) {
+      const expectedClaimValue = _.get(claimValue, k);
+      /*eslint-disable */
+      // Here we do want to use != and let the interpreter to auto cast and treat 20 equals to '20'
+      if (expectedClaimValue && _.get(ucaValueValue[k], 'value') != expectedClaimValue) {
         invalidValues.push(claimValue[k]);
       }
+      /* eslint-enable */
     });
   } else {
     // Invalid ucaValue.type

--- a/src/creds/VerifiableCredential.js
+++ b/src/creds/VerifiableCredential.js
@@ -84,12 +84,13 @@ function verifyLeave(leave, merkleTools, claims, signature, invalidValues, inval
     const ucaValueKeys = _.keys(ucaValue.value);
     _.each(ucaValueKeys, (k) => {
       const expectedClaimValue = _.get(claimValue, k);
-      /*eslint-disable */
-      // Here we do want to use != and let the interpreter to auto cast and treat 20 equals to '20'
-      if (expectedClaimValue && _.get(ucaValueValue[k], 'value') != expectedClaimValue) {
+
+      // Forcing string comparison just to keep !== and make the LINT happy!
+      // I'm sad...(CPU wasted) JS offers != has is way more elegant... read the next line like
+      // _.get(ucaValueValue[k], 'value') != {expectedClaimValue
+      if (expectedClaimValue && `${_.get(ucaValueValue[k], 'value')}` !== `${expectedClaimValue}`) {
         invalidValues.push(claimValue[k]);
       }
-      /* eslint-enable */
     });
   } else {
     // Invalid ucaValue.type


### PR DESCRIPTION
the original code `const claimValue = _.get(claims, leave.claimPath);`

returns an object like `{day: 1, month: 1, year: 1}` but the expectation was to an object like `{dateOfBirth:  {day: 1, month: 1, year: 1}}`

Because of that on the test line

`if (expectedClaimValue && _.get(ucaValueValue[k], 'value') != expectedClaimValue)`

`expectedClaimValue` was always undefined preventing the check at all, never pushing it to the `invalidValues`