### PR TITLE
Add verifyAll and change the verify(verificationLevel, options)

### DIFF
--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -795,7 +795,7 @@ describe('Unit tests for Verifiable Credentials', () => {
 
 
     const verifyLevel = receivedCred.verify(VC.VERIFY_LEVELS.GRANTED, { requestorId, requestId });
-    expect(verifyLevel).toBeGreaterThanOrEqual(VC.VERIFY_LEVELS.ANCHOR); // Should be at least one level lower
+    expect(verifyLevel).toBeGreaterThanOrEqual(VC.VERIFY_LEVELS.PROOFS); // Should be at least one level lower
 
     done();
   });

--- a/src/creds/VerifiableCredential.js
+++ b/src/creds/VerifiableCredential.js
@@ -476,15 +476,17 @@ function VerifiableCredentialBaseConstructor(identifier, issuer, expiryIn, ucas,
 
     // Test next level
     if (verifiedlevel === VERIFY_LEVELS.PROOFS
-        && hVerifyLevel >= VERIFY_LEVELS.ANCHOR
-        && this.verifyAttestation()) verifiedlevel = VERIFY_LEVELS.ANCHOR;
-
-    // Test next level
-    if (verifiedlevel === VERIFY_LEVELS.ANCHOR
         && hVerifyLevel >= VERIFY_LEVELS.GRANTED
         && this.verifyGrant(requestorId, requestId, keyName)) verifiedlevel = VERIFY_LEVELS.GRANTED;
 
     return verifiedlevel;
+  };
+
+  this.verifyAll = async (options) => {
+    const verifiedlevel = this.verify(VERIFY_LEVELS.GRANTED, options);
+    const anchored = await this.verifyAttestation();
+
+    return ((verifiedlevel === VERIFY_LEVELS.GRANTED) && anchored);
   };
 
   /**


### PR DESCRIPTION
Since `verifyAttestation()`  ins an ASYNC method it can't be part of the `verify` method. Changing the verify method to async will impact a lot of implementation that doesn't need to verify the anchor. This PR has a proposal to add a new ASYNC verification method `verifyAll` and remove the anchor verification for the `verify` method