### PR TITLE
Add support to required claims in the credentials definition

### DIFF
--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -42,6 +42,7 @@ describe('Unit tests for Verifiable Credentials', () => {
     }
     expect(createCredential).toThrowError('cvc:cred:Test is not defined');
   });
+
   test('Dont construct Credentials with wrong version', () => {
     function createCredential() {
       const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
@@ -50,6 +51,7 @@ describe('Unit tests for Verifiable Credentials', () => {
     }
     expect(createCredential).toThrowError('Credential definition for credential-cvc:Identity-v1 v2 not found');
   });
+
   test('New Defined Credentials', () => {
     const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
@@ -382,6 +384,7 @@ describe('Unit tests for Verifiable Credentials', () => {
     );
     expect(credential).toBeDefined();
   });
+
   it('Should filter claims for GenericDocumentId asking for cvc:Document:Type and return only that claim', () => {
     const typeValue = 'fq6gOJR2rr';
     const type = new Claim('claim-cvc:Document.type-v1', typeValue, '1');
@@ -1343,5 +1346,44 @@ describe('Unit tests for Verifiable Credentials', () => {
       return new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     }
     expect(createCredential).toThrowError('Evidence type is not an Array object');
+  });
+
+  it('Should create credential if non-required ucas are missing', () => {
+    const type = new Claim('claim-cvc:Document.type-v1', 'Passport', '1');
+    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
+    const issueCountry = new Claim('claim-cvc:Document.issueCountry-v1', 'Brazil', '1');
+    const dateOfBirthValue = { day: 20, month: 3, year: 1978 };
+    const dateOfBirth = new Claim('claim-cvc:Document.dateOfBirth-v1', dateOfBirthValue, '1');
+
+    const ucas = [type, name, issueCountry, dateOfBirth];
+    const credential = new VC('credential-cvc:IdDocument-v1', '', null, ucas, '1');
+
+    expect(credential).toBeDefined();
+  });
+
+  it('Should verify a VC without non-required claims', () => {
+    const credJSon = require('./fixtures/IdDocumentWithoutNonRequiredClaims.json'); // eslint-disable-line
+    const cred = VC.fromJSON(credJSon);
+    expect(cred).toBeDefined();
+    expect(cred.verifyProofs()).toBeTruthy();
+  });
+
+  it('Should throw exception on credential creation if required uca is missing', () => {
+    const type = new Claim('claim-cvc:Document.type-v1', 'Passport', '1');
+    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
+    const issueCountry = new Claim('claim-cvc:Document.issueCountry-v1', 'Brazil', '1');
+
+    const ucas = [type, name, issueCountry]; // dateOfBirth is missing
+
+    expect(() => {
+      new VC('credential-cvc:IdDocument-v1', '', null, ucas, '1'); // eslint-disable-line no-new
+    }).toThrow();
+  });
+
+  it('Should throw exception when creating a VC from json without required claims', () => {
+    const credJSon = require('./fixtures/IdDocumentWithoutRequiredClaims.json'); // eslint-disable-line
+    expect(() => {
+      VC.fromJSON(credJSon);
+    }).toThrow();
   });
 });

--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -1361,13 +1361,6 @@ describe('Unit tests for Verifiable Credentials', () => {
     expect(credential).toBeDefined();
   });
 
-  it('Should verify a VC without non-required claims', () => {
-    const credJSon = require('./fixtures/IdDocumentWithoutNonRequiredClaims.json'); // eslint-disable-line
-    const cred = VC.fromJSON(credJSon);
-    expect(cred).toBeDefined();
-    expect(cred.verifyProofs()).toBeTruthy();
-  });
-
   it('Should throw exception on credential creation if required uca is missing', () => {
     const type = new Claim('claim-cvc:Document.type-v1', 'Passport', '1');
     const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
@@ -1378,6 +1371,13 @@ describe('Unit tests for Verifiable Credentials', () => {
     expect(() => {
       new VC('credential-cvc:IdDocument-v1', '', null, ucas, '1'); // eslint-disable-line no-new
     }).toThrow();
+  });
+
+  it('Should verify a VC without non-required claims', () => {
+    const credJSon = require('./fixtures/IdDocumentWithoutNonRequiredClaims.json'); // eslint-disable-line
+    const cred = VC.fromJSON(credJSon);
+    expect(cred).toBeDefined();
+    expect(cred.verifyProofs()).toBeTruthy();
   });
 
   it('Should throw exception when creating a VC from json without required claims', () => {

--- a/__test__/creds/fixtures/IdDocumentWithoutNonRequiredClaims.json
+++ b/__test__/creds/fixtures/IdDocumentWithoutNonRequiredClaims.json
@@ -1,0 +1,218 @@
+{
+  "id": "23f3d617-6072-42d8-9dd3-f4321573362e",
+  "issuer": "",
+  "issuanceDate": "2019-06-05T18:38:24.211Z",
+  "identifier": "credential-cvc:IdDocument-v1",
+  "expirationDate": null,
+  "version": "1",
+  "type": [
+    "Credential",
+    "credential-cvc:IdDocument-v1"
+  ],
+  "claim": {
+    "document": {
+      "type": "Passport",
+      "name": {
+        "givenNames": "Lucas"
+      },
+      "issueCountry": "Brazil",
+      "dateOfBirth": {
+        "day": 20,
+        "month": 3,
+        "year": 1978
+      }
+    }
+  },
+  "proof": {
+    "type": "CvcMerkleProof2018",
+    "merkleRoot": "a27aa7be65666ebc5f92507d90cc62ac2c7f2116b784f5d33eb17864772dbdb2",
+    "anchor": "TBD (Civic Blockchain Attestation)",
+    "leaves": [
+      {
+        "identifier": "claim-cvc:Document.type-v1",
+        "value": "urn:type:1c5889708bfccd130742d4ce1e36b0c24c7857d66cd1a5afeae1134b27ee7a2d:Passport|",
+        "claimPath": "document.type",
+        "targetHash": "797a822b63909b6169509bcf48cc7bafca45b5feed36c0b16c40ac020a5a7bd0",
+        "node": [
+          {
+            "right": "7f9f89300c4e5b3c66eb349d599b271850e9ce0728349e8cc52225960db1cc9b"
+          },
+          {
+            "right": "62fb4d574720670ad073f77774bb4a4953131c128775725f305fd93551891509"
+          },
+          {
+            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.name-v1",
+        "value": "urn:name.givenNames:a6a8e8aac9d312bb86323b0af70831f1162a973e3f09ace0c953cf6285bd8592:Lucas|",
+        "claimPath": "document.name",
+        "targetHash": "7f9f89300c4e5b3c66eb349d599b271850e9ce0728349e8cc52225960db1cc9b",
+        "node": [
+          {
+            "left": "797a822b63909b6169509bcf48cc7bafca45b5feed36c0b16c40ac020a5a7bd0"
+          },
+          {
+            "right": "62fb4d574720670ad073f77774bb4a4953131c128775725f305fd93551891509"
+          },
+          {
+            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Name.givenNames-v1",
+        "value": "urn:givenNames:a6a8e8aac9d312bb86323b0af70831f1162a973e3f09ace0c953cf6285bd8592:Lucas|",
+        "claimPath": "document.name.givenNames",
+        "targetHash": "e0fe80be9804f82e5f60b28903894c0ad86c53e10303ad264f2904342303d8bc",
+        "node": [
+          {
+            "right": "f518f90669031dacacb6aff1fca97aa7594e45f7066edfd1e855d65e9a8e388b"
+          },
+          {
+            "left": "284120b493ebc3709821b1afad1939c3fd3bd6edc43aa6676b544416d619203e"
+          },
+          {
+            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.issueCountry-v1",
+        "value": "urn:issueCountry:1027a4cccfe115663fd4cfb1cf6ceee3290a719eda2612257c6a1565d1f1b295:Brazil|",
+        "claimPath": "document.issueCountry",
+        "targetHash": "f518f90669031dacacb6aff1fca97aa7594e45f7066edfd1e855d65e9a8e388b",
+        "node": [
+          {
+            "left": "e0fe80be9804f82e5f60b28903894c0ad86c53e10303ad264f2904342303d8bc"
+          },
+          {
+            "left": "284120b493ebc3709821b1afad1939c3fd3bd6edc43aa6676b544416d619203e"
+          },
+          {
+            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.dateOfBirth-v1",
+        "value": "urn:dateOfBirth.day:661cce9380f11ef947e53f526938fef45aacca628778efd47ed60dc5415a2121:20|urn:dateOfBirth.month:fa40772bf444dc523953889a17e7054b852fd7bf35a938c10939517897753372:3|urn:dateOfBirth.year:eb60320b1bb5048cd2bd4137b1acdc78277a16be8bf474151b8f53b647b425cf:1978|",
+        "claimPath": "document.dateOfBirth",
+        "targetHash": "eca5d49cc714eb8550795eacd90d556235739b530394a31c26d32642750ab978",
+        "node": [
+          {
+            "right": "9c6bb7a0f59c5d6d1635f0da673c956b192a229b0a5ba70dbb05647dcef86efb"
+          },
+          {
+            "right": "115478cf0862036826f845452a34c2933e7089ce35a805a450f764eae5ec9477"
+          },
+          {
+            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      },
+      {
+        "identifier": "cvc:Meta:issuer",
+        "value": "urn:issuer:54d7a94383424e4b72fe4454cbb37544daa2fd14495e6a41ab285128e0d97a3d:|",
+        "claimPath": "meta.issuer",
+        "targetHash": "9c6bb7a0f59c5d6d1635f0da673c956b192a229b0a5ba70dbb05647dcef86efb",
+        "node": [
+          {
+            "left": "eca5d49cc714eb8550795eacd90d556235739b530394a31c26d32642750ab978"
+          },
+          {
+            "right": "115478cf0862036826f845452a34c2933e7089ce35a805a450f764eae5ec9477"
+          },
+          {
+            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      },
+      {
+        "identifier": "cvc:Meta:issuanceDate",
+        "value": "urn:issuanceDate:903e422f155ef7a85f5e91e81bf5e865c123b5b615051d70670f6467d62daac2:2019-06-05T18:38:24.211Z|",
+        "claimPath": "meta.issuanceDate",
+        "targetHash": "c9aefb9e2e60d967e3176fb1764abfb1e3b00b0c5610416134d47906edf79d3a",
+        "node": [
+          {
+            "right": "b8140beac47ffa839df13b702adfcc33bc3a86046f3b3fedcea4d1f9c48288c0"
+          },
+          {
+            "left": "6d27b3389d41d2c52e5ae96fca575ad0b720182c2f987557d7813a4ae2678c4d"
+          },
+          {
+            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      },
+      {
+        "identifier": "cvc:Meta:expirationDate",
+        "value": "urn:expirationDate:bf11422365772ccaa9f2b3cb40980f5a735448ec56475b332e7b2d6755b89f60:null|",
+        "claimPath": "meta.expirationDate",
+        "targetHash": "b8140beac47ffa839df13b702adfcc33bc3a86046f3b3fedcea4d1f9c48288c0",
+        "node": [
+          {
+            "left": "c9aefb9e2e60d967e3176fb1764abfb1e3b00b0c5610416134d47906edf79d3a"
+          },
+          {
+            "left": "6d27b3389d41d2c52e5ae96fca575ad0b720182c2f987557d7813a4ae2678c4d"
+          },
+          {
+            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+          },
+          {
+            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+          },
+          {
+            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+          }
+        ]
+      }
+    ]
+  },
+  "granted": null
+}

--- a/__test__/creds/fixtures/IdDocumentWithoutRequiredClaims.json
+++ b/__test__/creds/fixtures/IdDocumentWithoutRequiredClaims.json
@@ -1,0 +1,190 @@
+{
+  "id": "31cd46c4-7165-42bd-8a31-c20c1dc0a629",
+  "issuer": "",
+  "issuanceDate": "2019-06-05T19:20:30.688Z",
+  "identifier": "credential-cvc:IdDocument-v1",
+  "expirationDate": null,
+  "version": "1",
+  "type": [
+    "Credential",
+    "credential-cvc:IdDocument-v1"
+  ],
+  "claim": {
+    "document": {
+      "type": "Passport",
+      "name": {
+        "givenNames": "Lucas"
+      },
+      "issueCountry": "Brazil"
+    }
+  },
+  "proof": {
+    "type": "CvcMerkleProof2018",
+    "merkleRoot": "e7f64a4cf0806ec7e20ec4387efa7e16bd1acbce74e313a10f103e93b3738fbf",
+    "anchor": "TBD (Civic Blockchain Attestation)",
+    "leaves": [
+      {
+        "identifier": "claim-cvc:Document.type-v1",
+        "value": "urn:type:83b6896ec68e5ec2702bfa6e89b26c4a886ee73eb22e3c0c5b9c893096a351ab:Passport|",
+        "claimPath": "document.type",
+        "targetHash": "34612fc426fa8199c256f86f6fee333cff72567626fb32ab8ddce0a922b27b03",
+        "node": [
+          {
+            "right": "9be5ee405cbe8c8a4f91cb0731213fcfa41b0b6b293f4b861a22ace736214674"
+          },
+          {
+            "right": "2ac677d8a50069fdf69d6f24b01219f86882f62f9c16c6e82dc06746f3060d19"
+          },
+          {
+            "right": "0328de70d7d76ebdd2865a4943ed394564426a8525ce532126e5f071e132136f"
+          },
+          {
+            "right": "2988aad4c88123d23e03f3aa5a85089cca99f3803d694a45b175efb5969d0eb2"
+          },
+          {
+            "right": "8f6f4e6cfd5feac30c987516ba35e865ed403b65595f3ea981a420055141b424"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.name-v1",
+        "value": "urn:name.givenNames:284e6fb1c2d4176d9e1630c61687a029979572b45f513927bab71589fc54fa29:Lucas|",
+        "claimPath": "document.name",
+        "targetHash": "9be5ee405cbe8c8a4f91cb0731213fcfa41b0b6b293f4b861a22ace736214674",
+        "node": [
+          {
+            "left": "34612fc426fa8199c256f86f6fee333cff72567626fb32ab8ddce0a922b27b03"
+          },
+          {
+            "right": "2ac677d8a50069fdf69d6f24b01219f86882f62f9c16c6e82dc06746f3060d19"
+          },
+          {
+            "right": "0328de70d7d76ebdd2865a4943ed394564426a8525ce532126e5f071e132136f"
+          },
+          {
+            "right": "2988aad4c88123d23e03f3aa5a85089cca99f3803d694a45b175efb5969d0eb2"
+          },
+          {
+            "right": "8f6f4e6cfd5feac30c987516ba35e865ed403b65595f3ea981a420055141b424"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Name.givenNames-v1",
+        "value": "urn:givenNames:284e6fb1c2d4176d9e1630c61687a029979572b45f513927bab71589fc54fa29:Lucas|",
+        "claimPath": "document.name.givenNames",
+        "targetHash": "759bccd7fa4af7e16867b0b57710f5d4a610857ea7e8d6614faccb5ae7b20077",
+        "node": [
+          {
+            "right": "da0e8cdb77405b37e09a8fd0f8c6ee7a0f18fc502748a90974951ac7929490cb"
+          },
+          {
+            "left": "4a03718df9750763893e0032331650fdb4932dade6ed409f51c41253b2cd3b8b"
+          },
+          {
+            "right": "0328de70d7d76ebdd2865a4943ed394564426a8525ce532126e5f071e132136f"
+          },
+          {
+            "right": "2988aad4c88123d23e03f3aa5a85089cca99f3803d694a45b175efb5969d0eb2"
+          },
+          {
+            "right": "8f6f4e6cfd5feac30c987516ba35e865ed403b65595f3ea981a420055141b424"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.issueCountry-v1",
+        "value": "urn:issueCountry:27d7b788ad59cc383fb1cb637826e211dec7de39a5489edc0b149c0f65b9b7f6:Brazil|",
+        "claimPath": "document.issueCountry",
+        "targetHash": "da0e8cdb77405b37e09a8fd0f8c6ee7a0f18fc502748a90974951ac7929490cb",
+        "node": [
+          {
+            "left": "759bccd7fa4af7e16867b0b57710f5d4a610857ea7e8d6614faccb5ae7b20077"
+          },
+          {
+            "left": "4a03718df9750763893e0032331650fdb4932dade6ed409f51c41253b2cd3b8b"
+          },
+          {
+            "right": "0328de70d7d76ebdd2865a4943ed394564426a8525ce532126e5f071e132136f"
+          },
+          {
+            "right": "2988aad4c88123d23e03f3aa5a85089cca99f3803d694a45b175efb5969d0eb2"
+          },
+          {
+            "right": "8f6f4e6cfd5feac30c987516ba35e865ed403b65595f3ea981a420055141b424"
+          }
+        ]
+      },
+      {
+        "identifier": "cvc:Meta:issuer",
+        "value": "urn:issuer:582e1ecbbc557e077bd0c4e827d8da0602a6a75b672aec5ecf292e8a1ca0b7b8:|",
+        "claimPath": "meta.issuer",
+        "targetHash": "9760de82d2f8ed5d64d4b2134d001f766d74c56b718c62eee495e16e0ebd4b71",
+        "node": [
+          {
+            "right": "9179950900a3d5273abeffdfc6042deed5bfec286e061bc7de52e7a825192eeb"
+          },
+          {
+            "right": "0be159b0efaaf9f7f53699f36e38c2a42e7416467c29ee4812c53d3aa9965eaa"
+          },
+          {
+            "left": "33e5280f9473fa50a39db90042a7a3d0f44614a1f7d7aedd868fbd0022d34d9e"
+          },
+          {
+            "right": "2988aad4c88123d23e03f3aa5a85089cca99f3803d694a45b175efb5969d0eb2"
+          },
+          {
+            "right": "8f6f4e6cfd5feac30c987516ba35e865ed403b65595f3ea981a420055141b424"
+          }
+        ]
+      },
+      {
+        "identifier": "cvc:Meta:issuanceDate",
+        "value": "urn:issuanceDate:c1c7ccedff8518269c43a881b9eb8047c7b97521d0354c6d38e55755be9d1fcf:2019-06-05T19:20:30.688Z|",
+        "claimPath": "meta.issuanceDate",
+        "targetHash": "9179950900a3d5273abeffdfc6042deed5bfec286e061bc7de52e7a825192eeb",
+        "node": [
+          {
+            "left": "9760de82d2f8ed5d64d4b2134d001f766d74c56b718c62eee495e16e0ebd4b71"
+          },
+          {
+            "right": "0be159b0efaaf9f7f53699f36e38c2a42e7416467c29ee4812c53d3aa9965eaa"
+          },
+          {
+            "left": "33e5280f9473fa50a39db90042a7a3d0f44614a1f7d7aedd868fbd0022d34d9e"
+          },
+          {
+            "right": "2988aad4c88123d23e03f3aa5a85089cca99f3803d694a45b175efb5969d0eb2"
+          },
+          {
+            "right": "8f6f4e6cfd5feac30c987516ba35e865ed403b65595f3ea981a420055141b424"
+          }
+        ]
+      },
+      {
+        "identifier": "cvc:Meta:expirationDate",
+        "value": "urn:expirationDate:484b45435b363728a261ac654556d0943279a4b0a8d01f93c4f01a677273aa27:null|",
+        "claimPath": "meta.expirationDate",
+        "targetHash": "3924e82d2ed8fcb8ce8a6478f42ae5c50d3b7e9fac707531cc2ec4bc305c3cd8",
+        "node": [
+          {
+            "right": "624ba87d3c589266c49166b118134209c832de54a80a540e04f517cde17bf439"
+          },
+          {
+            "left": "286b28037689c42a0647d466295f66b5949231e8ef4e798ea138136913d5a982"
+          },
+          {
+            "left": "33e5280f9473fa50a39db90042a7a3d0f44614a1f7d7aedd868fbd0022d34d9e"
+          },
+          {
+            "right": "2988aad4c88123d23e03f3aa5a85089cca99f3803d694a45b175efb5969d0eb2"
+          },
+          {
+            "right": "8f6f4e6cfd5feac30c987516ba35e865ed403b65595f3ea981a420055141b424"
+          }
+        ]
+      }
+    ]
+  },
+  "granted": null
+}

--- a/src/creds/definitions.js
+++ b/src/creds/definitions.js
@@ -51,6 +51,12 @@ const definitions = [
       'claim-cvc:Document.dateOfExpiry-v1',
       'claim-cvc:Document.nationality-v1',
     ],
+    required: [
+      'claim-cvc:Document.type-v1',
+      'claim-cvc:Document.name-v1',
+      'claim-cvc:Document.dateOfBirth-v1',
+      'claim-cvc:Document.issueCountry-v1',
+    ],
   },
   {
     identifier: 'credential-cvc:Address-v1',


### PR DESCRIPTION
Credential definition now supports a `required` attribute with the list of mandatory claims. The required claims are checked on Verifiable Credential construction (when using the regular constructor or building from JSON).

Required claims were defined for the `idDocument` credential:
```
  {
    identifier: 'credential-cvc:IdDocument-v1',
    version: '1',
    depends: [
      'claim-cvc:Document.type-v1',
      'claim-cvc:Document.number-v1',
      'claim-cvc:Document.name-v1',
      'claim-cvc:Document.gender-v1',
      'claim-cvc:Document.issueCountry-v1',
      'claim-cvc:Document.placeOfBirth-v1',
      'claim-cvc:Document.dateOfBirth-v1',
      'claim-cvc:Document.dateOfExpiry-v1',
      'claim-cvc:Document.nationality-v1',
    ],
    required: [
      'claim-cvc:Document.type-v1',
      'claim-cvc:Document.name-v1',
      'claim-cvc:Document.dateOfBirth-v1',
      'claim-cvc:Document.issueCountry-v1',
    ],
  },
```