### PR TITLE
Add evidences to IdDocument credential

### DIFF
--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -261,7 +261,7 @@ describe('Unit tests for Verifiable Credentials', () => {
 
   it('Should filter claims for GenericDocumentId asking for claim-cvc:Identity.dateOfBirth-v1 and return nothing',
     () => {
-      const typeValue = 'fq6gOJR2rr';
+      const typeValue = 'passport';
       const type = new Claim('claim-cvc:Document.type-v1', typeValue, '1');
       const numberValue = '3bj1LUg9yG';
       const number = new Claim('claim-cvc:Document.number-v1', numberValue, '1');
@@ -348,7 +348,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('Should create DocumentId credential', () => {
-    const typeValue = 'Passport';
+    const typeValue = 'passport';
     const type = new Claim('claim-cvc:Document.type-v1', typeValue, '1');
     const numberValue = 'FP12345';
     const number = new Claim('claim-cvc:Document.number-v1', numberValue, '1');
@@ -378,15 +378,29 @@ describe('Unit tests for Verifiable Credentials', () => {
     const dateOfExpiry = new Claim('claim-cvc:Document.dateOfExpiry-v1', dateOfExpiryValue, '1');
     const nationalityValue = 'Brazilian';
     const nationality = new Claim('claim-cvc:Document.nationality-v1', nationalityValue, '1');
+    const evidences = new Claim('claim-cvc:Document.evidences-v1', {
+      idDocumentFront: {
+        algorithm: 'sha256',
+        data: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      },
+      idDocumentBack: {
+        algorithm: 'sha256',
+        data: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      },
+      selfie: {
+        algorithm: 'sha256',
+        data: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      },
+    }, '1');
     const credential = new VC(
       'credential-cvc:IdDocument-v1', '', null, [type, number, name, gender,
-        issueCountry, placeOfBirth, dateOfBirth, dateOfExpiry, nationality], '1',
+        issueCountry, placeOfBirth, dateOfBirth, dateOfExpiry, nationality, evidences], '1',
     );
     expect(credential).toBeDefined();
   });
 
   it('Should filter claims for GenericDocumentId asking for cvc:Document:Type and return only that claim', () => {
-    const typeValue = 'fq6gOJR2rr';
+    const typeValue = 'passport';
     const type = new Claim('claim-cvc:Document.type-v1', typeValue, '1');
     const numberValue = '3bj1LUg9yG';
     const number = new Claim('claim-cvc:Document.number-v1', numberValue, '1');
@@ -448,7 +462,7 @@ describe('Unit tests for Verifiable Credentials', () => {
     );
     const filtered = credential.filter(['claim-cvc:Document.type-v1']);
 
-    expect(filtered.claim.document.type).toBe('fq6gOJR2rr');
+    expect(filtered.claim.document.type).toBe('passport');
   });
 
   it('Should verify an VC of type Email', () => {
@@ -1349,20 +1363,33 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('Should create credential if non-required ucas are missing', () => {
-    const type = new Claim('claim-cvc:Document.type-v1', 'Passport', '1');
+    const type = new Claim('claim-cvc:Document.type-v1', 'passport', '1');
     const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
     const issueCountry = new Claim('claim-cvc:Document.issueCountry-v1', 'Brazil', '1');
     const dateOfBirthValue = { day: 20, month: 3, year: 1978 };
     const dateOfBirth = new Claim('claim-cvc:Document.dateOfBirth-v1', dateOfBirthValue, '1');
-
-    const ucas = [type, name, issueCountry, dateOfBirth];
+    const evidences = new Claim('claim-cvc:Document.evidences-v1', {
+      idDocumentFront: {
+        algorithm: 'sha256',
+        data: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      },
+      idDocumentBack: {
+        algorithm: 'sha256',
+        data: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      },
+      selfie: {
+        algorithm: 'sha256',
+        data: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
+      },
+    }, '1');
+    const ucas = [type, name, issueCountry, dateOfBirth, evidences];
     const credential = new VC('credential-cvc:IdDocument-v1', '', null, ucas, '1');
 
     expect(credential).toBeDefined();
   });
 
   it('Should throw exception on credential creation if required uca is missing', () => {
-    const type = new Claim('claim-cvc:Document.type-v1', 'Passport', '1');
+    const type = new Claim('claim-cvc:Document.type-v1', 'passport', '1');
     const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
     const issueCountry = new Claim('claim-cvc:Document.issueCountry-v1', 'Brazil', '1');
 

--- a/__test__/creds/fixtures/IdDocumentWithoutNonRequiredClaims.json
+++ b/__test__/creds/fixtures/IdDocumentWithoutNonRequiredClaims.json
@@ -1,7 +1,7 @@
 {
-  "id": "23f3d617-6072-42d8-9dd3-f4321573362e",
+  "id": "0b41d088-03cb-4cce-b5c8-908fb6207cac",
   "issuer": "",
-  "issuanceDate": "2019-06-05T18:38:24.211Z",
+  "issuanceDate": "2019-06-18T18:40:43.324Z",
   "identifier": "credential-cvc:IdDocument-v1",
   "expirationDate": null,
   "version": "1",
@@ -12,203 +12,472 @@
   "claim": {
     "document": {
       "type": "Passport",
+      "number": "FP12345",
       "name": {
-        "givenNames": "Lucas"
+        "familyNames": "e8qak1",
+        "givenNames": "e8qhs4Iak1",
+        "otherNames": "qhs4I"
       },
+      "gender": "M",
       "issueCountry": "Brazil",
+      "placeOfBirth": "Belo Horizonte",
       "dateOfBirth": {
         "day": 20,
         "month": 3,
         "year": 1978
+      },
+      "dateOfExpiry": {
+        "day": 12,
+        "month": 2,
+        "year": 2025
+      },
+      "nationality": "Brazilian",
+      "evidences": {
+        "idDocumentBack": {
+          "algorithm": "sha256",
+          "data": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        "idDocumentFront": {
+          "algorithm": "sha256",
+          "data": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        },
+        "selfie": {
+          "algorithm": "sha256",
+          "data": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
       }
     }
   },
   "proof": {
     "type": "CvcMerkleProof2018",
-    "merkleRoot": "a27aa7be65666ebc5f92507d90cc62ac2c7f2116b784f5d33eb17864772dbdb2",
+    "merkleRoot": "287caa502816149f9787c6ab77d7161c45045b6e06659cf6ea94575d7ba3ae2a",
     "anchor": "TBD (Civic Blockchain Attestation)",
     "leaves": [
       {
         "identifier": "claim-cvc:Document.type-v1",
-        "value": "urn:type:1c5889708bfccd130742d4ce1e36b0c24c7857d66cd1a5afeae1134b27ee7a2d:Passport|",
+        "value": "urn:type:e2e862de517ce17d552f985b44c801d56b203d53a3da611b1d13e6a860f96f4d:Passport|",
         "claimPath": "document.type",
-        "targetHash": "797a822b63909b6169509bcf48cc7bafca45b5feed36c0b16c40ac020a5a7bd0",
+        "targetHash": "7f3038b53480db16f959050ae61021933460822855204bbe9a4a1f6e8a3d0116",
         "node": [
           {
-            "right": "7f9f89300c4e5b3c66eb349d599b271850e9ce0728349e8cc52225960db1cc9b"
+            "right": "30ac51aa0955500498a1b0b4771c7d762d51ba325d71f33d991f9dd9d2761560"
           },
           {
-            "right": "62fb4d574720670ad073f77774bb4a4953131c128775725f305fd93551891509"
+            "right": "bc79b4b362ba3df5631ab6abf95a9b61cc03eb287c3ebeb8284a61c030d6bbd0"
           },
           {
-            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+            "right": "8960a6b8304488e88f5c9a94d9eefb3a204038f68a65835d336f66eb671193a3"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
           },
           {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.number-v1",
+        "value": "urn:number:5f9e5213d98a47958f0ca35ce61b719f60be3c28e6470a608bcafd6425cb26db:FP12345|",
+        "claimPath": "document.number",
+        "targetHash": "30ac51aa0955500498a1b0b4771c7d762d51ba325d71f33d991f9dd9d2761560",
+        "node": [
+          {
+            "left": "7f3038b53480db16f959050ae61021933460822855204bbe9a4a1f6e8a3d0116"
+          },
+          {
+            "right": "bc79b4b362ba3df5631ab6abf95a9b61cc03eb287c3ebeb8284a61c030d6bbd0"
+          },
+          {
+            "right": "8960a6b8304488e88f5c9a94d9eefb3a204038f68a65835d336f66eb671193a3"
+          },
+          {
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
           }
         ]
       },
       {
         "identifier": "claim-cvc:Document.name-v1",
-        "value": "urn:name.givenNames:a6a8e8aac9d312bb86323b0af70831f1162a973e3f09ace0c953cf6285bd8592:Lucas|",
+        "value": "urn:name.familyNames:27b5254a5a0da53721c8a19940d43b7f23ee53355339b68876ca4f026c206f67:e8qak1|urn:name.givenNames:ea26343fd3bb2ac7b38978b8a3ed979a66fdb4e51cf57c8b39ec20bb16a7a7f1:e8qhs4Iak1|urn:name.otherNames:9c0bf86efabbd942565e66ff5549a1e69316f220e5b11b74b2382efa7ef619e4:qhs4I|",
         "claimPath": "document.name",
-        "targetHash": "7f9f89300c4e5b3c66eb349d599b271850e9ce0728349e8cc52225960db1cc9b",
+        "targetHash": "1685e316cdb23cbd1c6d77fbc832f7860d207a117804cba28ac887e4fc479705",
         "node": [
           {
-            "left": "797a822b63909b6169509bcf48cc7bafca45b5feed36c0b16c40ac020a5a7bd0"
+            "right": "05a43d95727cb6e14b3843e48da8cfd11634c6a4f13c72478acae8656ab8eb61"
           },
           {
-            "right": "62fb4d574720670ad073f77774bb4a4953131c128775725f305fd93551891509"
+            "left": "9c62a73848c4e5af6fd138ceeb52ad67937266707ee15be238e949ad915ddcac"
           },
           {
-            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+            "right": "8960a6b8304488e88f5c9a94d9eefb3a204038f68a65835d336f66eb671193a3"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
           },
           {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
           }
         ]
       },
       {
         "identifier": "claim-cvc:Name.givenNames-v1",
-        "value": "urn:givenNames:a6a8e8aac9d312bb86323b0af70831f1162a973e3f09ace0c953cf6285bd8592:Lucas|",
+        "value": "urn:givenNames:ea26343fd3bb2ac7b38978b8a3ed979a66fdb4e51cf57c8b39ec20bb16a7a7f1:e8qhs4Iak1|",
         "claimPath": "document.name.givenNames",
-        "targetHash": "e0fe80be9804f82e5f60b28903894c0ad86c53e10303ad264f2904342303d8bc",
+        "targetHash": "05a43d95727cb6e14b3843e48da8cfd11634c6a4f13c72478acae8656ab8eb61",
         "node": [
           {
-            "right": "f518f90669031dacacb6aff1fca97aa7594e45f7066edfd1e855d65e9a8e388b"
+            "left": "1685e316cdb23cbd1c6d77fbc832f7860d207a117804cba28ac887e4fc479705"
           },
           {
-            "left": "284120b493ebc3709821b1afad1939c3fd3bd6edc43aa6676b544416d619203e"
+            "left": "9c62a73848c4e5af6fd138ceeb52ad67937266707ee15be238e949ad915ddcac"
           },
           {
-            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+            "right": "8960a6b8304488e88f5c9a94d9eefb3a204038f68a65835d336f66eb671193a3"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
           },
           {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Name.familyNames-v1",
+        "value": "urn:familyNames:27b5254a5a0da53721c8a19940d43b7f23ee53355339b68876ca4f026c206f67:e8qak1|",
+        "claimPath": "document.name.familyNames",
+        "targetHash": "d6276700ed3070f923b013c051bcd5fb6f73981a873e0b82d6f328dc4d2be4ea",
+        "node": [
+          {
+            "right": "807fd50603579963b55aa117f07bab90d0882b317ea31817f4d0efc9fe74258a"
+          },
+          {
+            "right": "e82cfc4a020cf3ccaf42dc07bd99b8bfebf213655ce069742cb77110b9de304d"
+          },
+          {
+            "left": "d5d87dc0138b470774f7affe3a0efbadfd621bc57c00c14a62ef4caaa9d45987"
+          },
+          {
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Name.otherNames-v1",
+        "value": "urn:otherNames:9c0bf86efabbd942565e66ff5549a1e69316f220e5b11b74b2382efa7ef619e4:qhs4I|",
+        "claimPath": "document.name.otherNames",
+        "targetHash": "807fd50603579963b55aa117f07bab90d0882b317ea31817f4d0efc9fe74258a",
+        "node": [
+          {
+            "left": "d6276700ed3070f923b013c051bcd5fb6f73981a873e0b82d6f328dc4d2be4ea"
+          },
+          {
+            "right": "e82cfc4a020cf3ccaf42dc07bd99b8bfebf213655ce069742cb77110b9de304d"
+          },
+          {
+            "left": "d5d87dc0138b470774f7affe3a0efbadfd621bc57c00c14a62ef4caaa9d45987"
+          },
+          {
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.gender-v1",
+        "value": "urn:gender:95f7a5eb0e64cc63d5ebc3cd2316db75541f070e426dca7e2db5690c9b20a17f:M|",
+        "claimPath": "document.gender",
+        "targetHash": "2a9b491d5e669fd4c8663cab06e896e81da82fc5927b49e1dbf7c0bd92c041f5",
+        "node": [
+          {
+            "right": "8f424b01c81efb1178e9026f2247135f77ec8b2e28b8b6cd5cb3c242f9c3aff0"
+          },
+          {
+            "left": "30887eb2255aa9c4790f4033c4ec750325cca28ac0f38f1d7291cbbe497e3490"
+          },
+          {
+            "left": "d5d87dc0138b470774f7affe3a0efbadfd621bc57c00c14a62ef4caaa9d45987"
+          },
+          {
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
           }
         ]
       },
       {
         "identifier": "claim-cvc:Document.issueCountry-v1",
-        "value": "urn:issueCountry:1027a4cccfe115663fd4cfb1cf6ceee3290a719eda2612257c6a1565d1f1b295:Brazil|",
+        "value": "urn:issueCountry:26015cb27ac94844cb265b55856e43e8b43ccfe8ab8e76a71654d8ee61ed1e91:Brazil|",
         "claimPath": "document.issueCountry",
-        "targetHash": "f518f90669031dacacb6aff1fca97aa7594e45f7066edfd1e855d65e9a8e388b",
+        "targetHash": "8f424b01c81efb1178e9026f2247135f77ec8b2e28b8b6cd5cb3c242f9c3aff0",
         "node": [
           {
-            "left": "e0fe80be9804f82e5f60b28903894c0ad86c53e10303ad264f2904342303d8bc"
+            "left": "2a9b491d5e669fd4c8663cab06e896e81da82fc5927b49e1dbf7c0bd92c041f5"
           },
           {
-            "left": "284120b493ebc3709821b1afad1939c3fd3bd6edc43aa6676b544416d619203e"
+            "left": "30887eb2255aa9c4790f4033c4ec750325cca28ac0f38f1d7291cbbe497e3490"
           },
           {
-            "right": "0cb4e19cb93c0e13d3d5b1ca9a9c83373285a98ec8c07491916859229d141915"
+            "left": "d5d87dc0138b470774f7affe3a0efbadfd621bc57c00c14a62ef4caaa9d45987"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+            "right": "52cfc99632cdacba9c14728c7e90f25aa7109ed98b6b5446cf049b4d861a428b"
           },
           {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.placeOfBirth-v1",
+        "value": "urn:placeOfBirth:ab9ebaf999a0a7b08de876e96b1f728ae480f8b054ca81e6ee6b6eb357aaae1d:Belo Horizonte|",
+        "claimPath": "document.placeOfBirth",
+        "targetHash": "e9905e6f38a2f13985e96f305ce80f4919de9b6753a6248ade279f7b1718837b",
+        "node": [
+          {
+            "right": "1d41f39d93a7c21f9a545331735f80636bd63e1d4a10538d64973e9515e2b198"
+          },
+          {
+            "right": "71f311383be069133baf8af0fe381bea0aaed4d4de374c68c9ac089167699a2b"
+          },
+          {
+            "right": "5f8fec66c1df66d4bca8b38c07536946640380614a0884e3422ee1eb35bdfadf"
+          },
+          {
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
           }
         ]
       },
       {
         "identifier": "claim-cvc:Document.dateOfBirth-v1",
-        "value": "urn:dateOfBirth.day:661cce9380f11ef947e53f526938fef45aacca628778efd47ed60dc5415a2121:20|urn:dateOfBirth.month:fa40772bf444dc523953889a17e7054b852fd7bf35a938c10939517897753372:3|urn:dateOfBirth.year:eb60320b1bb5048cd2bd4137b1acdc78277a16be8bf474151b8f53b647b425cf:1978|",
+        "value": "urn:dateOfBirth.day:11f75d1de599c5edee287ee4f4c7967ceb69a6707da0bc6a5dd97550c570d7db:20|urn:dateOfBirth.month:4a551178fdc75854ffef6e83b330156b36c423891a3f876972190a942bc265a7:3|urn:dateOfBirth.year:f12af3a4cc5cac31520e90d3cd9416b3174247fe1cf5b8c2c348249e62373f87:1978|",
         "claimPath": "document.dateOfBirth",
-        "targetHash": "eca5d49cc714eb8550795eacd90d556235739b530394a31c26d32642750ab978",
+        "targetHash": "1d41f39d93a7c21f9a545331735f80636bd63e1d4a10538d64973e9515e2b198",
         "node": [
           {
-            "right": "9c6bb7a0f59c5d6d1635f0da673c956b192a229b0a5ba70dbb05647dcef86efb"
+            "left": "e9905e6f38a2f13985e96f305ce80f4919de9b6753a6248ade279f7b1718837b"
           },
           {
-            "right": "115478cf0862036826f845452a34c2933e7089ce35a805a450f764eae5ec9477"
+            "right": "71f311383be069133baf8af0fe381bea0aaed4d4de374c68c9ac089167699a2b"
           },
           {
-            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+            "right": "5f8fec66c1df66d4bca8b38c07536946640380614a0884e3422ee1eb35bdfadf"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
           },
           {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.dateOfExpiry-v1",
+        "value": "urn:dateOfExpiry.day:1ac23cac425819692044482563516f24a57be63468e4f8d7b0e127a8f35bd535:12|urn:dateOfExpiry.month:9c962026289b6cc25eae1a74e2a599194ab3adf144f900b15e09dfb67887471a:2|urn:dateOfExpiry.year:fb8d624c780ac0a87b87c8e8ec5861cb902f5aa186ffc3fecb72e2b004d60fc9:2025|",
+        "claimPath": "document.dateOfExpiry",
+        "targetHash": "4ed1ed6ccad83c10ba3bf6aad4d241b5ba77b885cb7dbf51cbc2bd46063d0ccd",
+        "node": [
+          {
+            "right": "cdc4c59ad08d3af4ca9fa882395ad528df8b92cd5d6960f69e0f9006095b2a23"
+          },
+          {
+            "left": "bad3055592187467ef5b1caa9c6e9d637ed520cc8e2abdf72e4958a0a7b727de"
+          },
+          {
+            "right": "5f8fec66c1df66d4bca8b38c07536946640380614a0884e3422ee1eb35bdfadf"
+          },
+          {
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.nationality-v1",
+        "value": "urn:nationality:24c38aacc4a7764f0c535a8a01c19f7551ca97a88242a5c06e416593fc24c2e4:Brazilian|",
+        "claimPath": "document.nationality",
+        "targetHash": "cdc4c59ad08d3af4ca9fa882395ad528df8b92cd5d6960f69e0f9006095b2a23",
+        "node": [
+          {
+            "left": "4ed1ed6ccad83c10ba3bf6aad4d241b5ba77b885cb7dbf51cbc2bd46063d0ccd"
+          },
+          {
+            "left": "bad3055592187467ef5b1caa9c6e9d637ed520cc8e2abdf72e4958a0a7b727de"
+          },
+          {
+            "right": "5f8fec66c1df66d4bca8b38c07536946640380614a0884e3422ee1eb35bdfadf"
+          },
+          {
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Document.evidences-v1",
+        "value": "urn:evidences.idDocumentBack.algorithm:2d0f9636ca117366dd97dd69f2a9a63b99e634d37f612ceeffa12a30db9a86d5:sha256|urn:evidences.idDocumentBack.data:620b742575b5f52ca5d03c29efd5cf3c17ca6a52116deff07f2ea09a8ef63dbf:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|urn:evidences.idDocumentFront.algorithm:bcbd9b333241be0fb62f29dd9c9b1165cceb4408aaa955a7ef9c8ba9de952088:sha256|urn:evidences.idDocumentFront.data:273f235a2730fd2a18c5ab669fa7e2c78e63a5e2806677cd5d4075596dd9529f:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|urn:evidences.selfie.algorithm:2f79f2e31a9ce9bc774eb89468e6484a23ff9e619d2bf30a0bb23a7ba884f1af:sha256|urn:evidences.selfie.data:d44efec6c580b3b1300801e594bd4c615309d5604442b8699d34e503b0be9312:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|",
+        "claimPath": "document.evidences",
+        "targetHash": "2e19a0209d987aeff1d56ff2be7b7e2af83d3abc17cf951ddb47cb4515511305",
+        "node": [
+          {
+            "right": "dadad5ed64260bebb3e2f5fdf8c66109d6faba308b2483d22251082890e9009f"
+          },
+          {
+            "right": "f44b7344b7b49b9876817c52e328112f139b6443ce3dcb72ed450b6186b58dff"
+          },
+          {
+            "left": "af8d81492cf8d727f2749d4b10a19c19ded0eb4d93342fde11cc7e6866b8e566"
+          },
+          {
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Validation:evidences.idDocumentFront-v1",
+        "value": "urn:idDocumentFront.algorithm:bcbd9b333241be0fb62f29dd9c9b1165cceb4408aaa955a7ef9c8ba9de952088:sha256|urn:idDocumentFront.data:273f235a2730fd2a18c5ab669fa7e2c78e63a5e2806677cd5d4075596dd9529f:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|",
+        "claimPath": "validationEvidences.idDocumentFront",
+        "targetHash": "dadad5ed64260bebb3e2f5fdf8c66109d6faba308b2483d22251082890e9009f",
+        "node": [
+          {
+            "left": "2e19a0209d987aeff1d56ff2be7b7e2af83d3abc17cf951ddb47cb4515511305"
+          },
+          {
+            "right": "f44b7344b7b49b9876817c52e328112f139b6443ce3dcb72ed450b6186b58dff"
+          },
+          {
+            "left": "af8d81492cf8d727f2749d4b10a19c19ded0eb4d93342fde11cc7e6866b8e566"
+          },
+          {
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Validation:evidences.idDocumentBack-v1",
+        "value": "urn:idDocumentBack.algorithm:2d0f9636ca117366dd97dd69f2a9a63b99e634d37f612ceeffa12a30db9a86d5:sha256|urn:idDocumentBack.data:620b742575b5f52ca5d03c29efd5cf3c17ca6a52116deff07f2ea09a8ef63dbf:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|",
+        "claimPath": "validationEvidences.idDocumentBack",
+        "targetHash": "e3a604848f2bcee8f2e580c4a72bca8666421efe03deb9ad719d2513e242daf1",
+        "node": [
+          {
+            "right": "6f1a450426909a5920eb9d44be17b94ad6df1b93cc9422464c1d85f01daf16bc"
+          },
+          {
+            "left": "954f2146938ca577eed53690bf9776775d1634af53a8f6abeacb1805b7a92c10"
+          },
+          {
+            "left": "af8d81492cf8d727f2749d4b10a19c19ded0eb4d93342fde11cc7e6866b8e566"
+          },
+          {
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
+          }
+        ]
+      },
+      {
+        "identifier": "claim-cvc:Validation:evidences.selfie-v1",
+        "value": "urn:selfie.algorithm:2f79f2e31a9ce9bc774eb89468e6484a23ff9e619d2bf30a0bb23a7ba884f1af:sha256|urn:selfie.data:d44efec6c580b3b1300801e594bd4c615309d5604442b8699d34e503b0be9312:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855|",
+        "claimPath": "validationEvidences.selfie",
+        "targetHash": "6f1a450426909a5920eb9d44be17b94ad6df1b93cc9422464c1d85f01daf16bc",
+        "node": [
+          {
+            "left": "e3a604848f2bcee8f2e580c4a72bca8666421efe03deb9ad719d2513e242daf1"
+          },
+          {
+            "left": "954f2146938ca577eed53690bf9776775d1634af53a8f6abeacb1805b7a92c10"
+          },
+          {
+            "left": "af8d81492cf8d727f2749d4b10a19c19ded0eb4d93342fde11cc7e6866b8e566"
+          },
+          {
+            "left": "7928776907776ed7bece599ffcd96b65de5f5340834af968b5089b01d69f7b62"
+          },
+          {
+            "right": "52e2e64063c533f9419667ced3c3a79582f9e560b9de8bd52cb5c6cd0e0f5e48"
           }
         ]
       },
       {
         "identifier": "cvc:Meta:issuer",
-        "value": "urn:issuer:54d7a94383424e4b72fe4454cbb37544daa2fd14495e6a41ab285128e0d97a3d:|",
+        "value": "urn:issuer:292b0049dfd8c15f0310c760b6fbe8a8485b9beb389ba29262604510877a5cfb:|",
         "claimPath": "meta.issuer",
-        "targetHash": "9c6bb7a0f59c5d6d1635f0da673c956b192a229b0a5ba70dbb05647dcef86efb",
+        "targetHash": "f8fadea6eab4ae1c5e81c36778d2756c38c84b92eaa11d0ea2841577d8dbc816",
         "node": [
           {
-            "left": "eca5d49cc714eb8550795eacd90d556235739b530394a31c26d32642750ab978"
+            "right": "731b43aca212bd7a1de986a939c8e9fed0d079d1cc638ffa17550d78d202159a"
           },
           {
-            "right": "115478cf0862036826f845452a34c2933e7089ce35a805a450f764eae5ec9477"
+            "right": "765f969858f73f8722f132ed0f54ca563bf4dcf01dbb63050befc60f5c2689d6"
           },
           {
-            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+            "right": "57c3b18b1e5bc473a1b957ffbed2367943e17a4c46783e082ec73201422c7e0d"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
-          },
-          {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "left": "fc861ec3a17be8fd5a4b447d10516ed8721f0cc0e16dd697dc2586986c94a3ac"
           }
         ]
       },
       {
         "identifier": "cvc:Meta:issuanceDate",
-        "value": "urn:issuanceDate:903e422f155ef7a85f5e91e81bf5e865c123b5b615051d70670f6467d62daac2:2019-06-05T18:38:24.211Z|",
+        "value": "urn:issuanceDate:f548bd51bd8e6067af740f98e78eba10d327abf31352f902e10acac9e244d7da:2019-06-18T18:40:43.324Z|",
         "claimPath": "meta.issuanceDate",
-        "targetHash": "c9aefb9e2e60d967e3176fb1764abfb1e3b00b0c5610416134d47906edf79d3a",
+        "targetHash": "731b43aca212bd7a1de986a939c8e9fed0d079d1cc638ffa17550d78d202159a",
         "node": [
           {
-            "right": "b8140beac47ffa839df13b702adfcc33bc3a86046f3b3fedcea4d1f9c48288c0"
+            "left": "f8fadea6eab4ae1c5e81c36778d2756c38c84b92eaa11d0ea2841577d8dbc816"
           },
           {
-            "left": "6d27b3389d41d2c52e5ae96fca575ad0b720182c2f987557d7813a4ae2678c4d"
+            "right": "765f969858f73f8722f132ed0f54ca563bf4dcf01dbb63050befc60f5c2689d6"
           },
           {
-            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+            "right": "57c3b18b1e5bc473a1b957ffbed2367943e17a4c46783e082ec73201422c7e0d"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
-          },
-          {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "left": "fc861ec3a17be8fd5a4b447d10516ed8721f0cc0e16dd697dc2586986c94a3ac"
           }
         ]
       },
       {
         "identifier": "cvc:Meta:expirationDate",
-        "value": "urn:expirationDate:bf11422365772ccaa9f2b3cb40980f5a735448ec56475b332e7b2d6755b89f60:null|",
+        "value": "urn:expirationDate:54a7ae635fbc7a1f4280464724001b9b5717e075569df07f737fb67e37d84a55:null|",
         "claimPath": "meta.expirationDate",
-        "targetHash": "b8140beac47ffa839df13b702adfcc33bc3a86046f3b3fedcea4d1f9c48288c0",
+        "targetHash": "c995d499a9af3ca85e519bfaa48fb72fc8f180c7cfae58f7991aa86194e20460",
         "node": [
           {
-            "left": "c9aefb9e2e60d967e3176fb1764abfb1e3b00b0c5610416134d47906edf79d3a"
+            "right": "d3a8e00d2496a1a4276f195d29457a9ab572f0367e807837ba1b22cefa383f5d"
           },
           {
-            "left": "6d27b3389d41d2c52e5ae96fca575ad0b720182c2f987557d7813a4ae2678c4d"
+            "left": "86e5e3315073bb73a898616d20e72161dd5ffe8aa6ddefab8e50e0d1e0e66c48"
           },
           {
-            "left": "2d99768e64c3c4f87b6f570b2b452b8b34e8bafe8a7889559b3db50479f0cc61"
+            "right": "57c3b18b1e5bc473a1b957ffbed2367943e17a4c46783e082ec73201422c7e0d"
           },
           {
-            "right": "ffb5c94607236d91daf7e122aa8771b12c2d8e0159c9c4583761fa048d439566"
-          },
-          {
-            "right": "62df7b1a39662240eb207565469b248f581e3abfd1261454eaf705cdb374bf27"
+            "left": "fc861ec3a17be8fd5a4b447d10516ed8721f0cc0e16dd697dc2586986c94a3ac"
           }
         ]
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,9 +229,9 @@
       }
     },
     "@identity.com/uca": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@identity.com/uca/-/uca-1.0.8.tgz",
-      "integrity": "sha512-DfbuhzfcF0FRVeZWWVDbDm4MrOBDU2MPnfG9Vt0UqG/gc7e2MViwHHn5LkVpOGAgAJRrEZMMMeAIhpbmmFbajg==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@identity.com/uca/-/uca-1.0.9.tgz",
+      "integrity": "sha512-ADoK7BlydtZjB0UP/wq31lKZYIE8o3HLTwU+Q2InQ5yWfw3LorWc+4uFlgMzcE/9QAMgOCl6CtXjzNWd3MuVaA==",
       "requires": {
         "flat": "^4.1.0",
         "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "@identity.com/uca": "1.0.8",
+    "@identity.com/uca": "1.0.9",
     "ajv": "^6.10.0",
     "babel-runtime": "^6.26.0",
     "bitcoinjs-lib": "git+https://github.com/dabura667/bitcoinjs-lib.git#bcash330",

--- a/src/claim/definitions.js
+++ b/src/claim/definitions.js
@@ -221,7 +221,7 @@ const definitions = [
   {
     identifier: 'claim-cvc:Document.type-v1',
     version: '1',
-    type: 'claim-cvc:Document.enum-v1',
+    type: 'cvc:Type:documentType',
     credentialItem: true,
   },
   {
@@ -402,6 +402,44 @@ const definitions = [
     identifier: 'claim-cvc:SocialSecurity.number-v1',
     version: '1',
     type: 'cvc:Type:socialSecurityNumber',
+    credentialItem: true,
+  },
+  {
+    identifier: 'claim-cvc:Validation:evidences.idDocumentFront-v1',
+    version: '1',
+    type: 'cvc:Type:idDocumentFront',
+    credentialItem: true,
+  },
+  {
+    identifier: 'claim-cvc:Validation:evidences.idDocumentBack-v1',
+    version: '1',
+    type: 'cvc:Type:idDocumentBack',
+    credentialItem: true,
+  },
+  {
+    identifier: 'claim-cvc:Validation:evidences.selfie-v1',
+    version: '1',
+    type: 'cvc:Type:selfie',
+    credentialItem: true,
+  },
+  {
+    identifier: 'claim-cvc:Document.evidences-v1',
+    version: '1',
+    attestable: true,
+    type: {
+      properties: [{
+        name: 'idDocumentFront',
+        type: 'claim-cvc:Validation:evidences.idDocumentFront-v1',
+      },
+      {
+        name: 'idDocumentBack',
+        type: 'claim-cvc:Validation:evidences.idDocumentBack-v1',
+      },
+      {
+        name: 'selfie',
+        type: 'claim-cvc:Validation:evidences.selfie-v1',
+      }],
+    },
     credentialItem: true,
   },
 ];

--- a/src/creds/definitions.js
+++ b/src/creds/definitions.js
@@ -50,12 +50,14 @@ const definitions = [
       'claim-cvc:Document.dateOfBirth-v1',
       'claim-cvc:Document.dateOfExpiry-v1',
       'claim-cvc:Document.nationality-v1',
+      'claim-cvc:Document.evidences-v1',
     ],
     required: [
       'claim-cvc:Document.type-v1',
       'claim-cvc:Document.name-v1',
       'claim-cvc:Document.dateOfBirth-v1',
       'claim-cvc:Document.issueCountry-v1',
+      'claim-cvc:Document.evidences-v1',
     ],
   },
   {

--- a/src/schemas/generator/SchemaGenerator.js
+++ b/src/schemas/generator/SchemaGenerator.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-use-before-define */
+const _ = require('lodash');
 const randomString = require('randomstring');
 const Type = require('type-of-is');
 const RandExp = require('randexp');
@@ -211,6 +212,9 @@ const generateRandomValueForType = (definition, includeDefinitions = false) => {
   // that's why the magic numbers are here
   switch (resolvedTypeName) {
     case 'String':
+      if (refDefinition.enum) {
+        return _.values(refDefinition.enum)[0];
+      }
       return refDefinition && refDefinition.pattern
         ? new RandExp(refDefinition.pattern).gen()
         : randomString.generate(10);


### PR DESCRIPTION
Adds: `claim-cvc:Document.evidences-v1` to `credential-cvc:IdDocument-v1`
Fix:  `claim-cvc:Document.type-v1` now it validates usuing the corret UCA enum
Update: SchemaGenerator to support enuns when creating random values