### PR TITLE
Handle alias UCAs on Claim transformation

### DIFF
--- a/__test__/claim/Claim.test.js
+++ b/__test__/claim/Claim.test.js
@@ -306,7 +306,7 @@ describe('Claim Constructions tests', () => {
 
     // converting UCAs to Claims
     const evidencesClaim = new Claim(identifier, evidencesUCA.getPlainValue());
-    const evidencesClaimForAliasUCA = new Claim(identifier, evidencesAliasUCA.getPlainValue());
+    const evidencesClaimForAliasUCA = new Claim(aliasIdentifier, evidencesAliasUCA.getPlainValue());
 
     // should map to the same claim
     expect(evidencesClaimForAliasUCA.identifier).toEqual(evidencesClaim.identifier);

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,8 +229,8 @@
       }
     },
     "@identity.com/uca": {
-      "version": "1.0.13",
-      "resolved": "git+https://github.com/identity-com/uca.git#254d3ceb68084786584fc7b09d7bf8488c715057",
+      "version": "git+https://github.com/identity-com/uca.git#49c11ecdbf802db6f5f2030b218d3acb38eabf4c",
+      "from": "git+https://github.com/identity-com/uca.git#49c11ecdbf802db6f5f2030b218d3acb38eabf4c",
       "requires": {
         "flat": "^4.1.0",
         "lodash": "^4.17.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -229,8 +229,9 @@
       }
     },
     "@identity.com/uca": {
-      "version": "git+https://github.com/identity-com/uca.git#49c11ecdbf802db6f5f2030b218d3acb38eabf4c",
-      "from": "git+https://github.com/identity-com/uca.git#49c11ecdbf802db6f5f2030b218d3acb38eabf4c",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@identity.com/uca/-/uca-1.0.14.tgz",
+      "integrity": "sha512-9DS9Ri3bIx1d9NYF+VWkX6I7bRf8lIK9r6eakUcZ+HHEPwOScTciRn2FoEf2wzR1ZUkU3zNVH7zNKscclmCgkQ==",
       "requires": {
         "flat": "^4.1.0",
         "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "author": "Identity.com Community",
   "license": "MIT",
   "description": "Verifiable Credential and Attestation Library",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "@identity.com/uca": "1.0.13",
+    "@identity.com/uca": "git+https://github.com/identity-com/uca#49c11ecdbf802db6f5f2030b218d3acb38eabf4c",
     "ajv": "^6.10.0",
     "babel-runtime": "^6.26.0",
     "bitcoinjs-lib": "git+https://github.com/dabura667/bitcoinjs-lib.git#bcash330",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "@identity.com/uca": "git+https://github.com/identity-com/uca#49c11ecdbf802db6f5f2030b218d3acb38eabf4c",
+    "@identity.com/uca": "1.0.14",
     "ajv": "^6.10.0",
     "babel-runtime": "^6.26.0",
     "bitcoinjs-lib": "git+https://github.com/dabura667/bitcoinjs-lib.git#bcash330",


### PR DESCRIPTION
Resolve UCAs type when it is a UCA with the `alias` flag on Claim conversion.