### PR TITLE
Methods to verify credentials

### DIFF
--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -568,6 +568,37 @@ describe('Unit tests for Verifiable Credentials', () => {
     expect(cred.verify()).toBeGreaterThanOrEqual(VC.VERIFY_LEVELS.PROOFS);
   });
 
+  it('Should verify an VC with no cryptographic security', () => {
+    const credJSon = require('./fixtures/PhoneNumber.json'); // eslint-disable-line
+    const credential = VC.fromJSON(credJSon);
+    expect(credential).toBeDefined();
+    const isValid = credential.nonCryptographicallySecureVerify();
+    expect(isValid).toBeTruthy();
+  });
+
+  it('Should verify a not anchored VC with non cryptographic verify', () => {
+    const value = {
+      country: '1ApYikRwDl',
+      countryCode: 'U4drpB96Hk',
+      number: 'kCTGifTdom',
+      extension: 'sXZpZJTe4R',
+      lineType: 'OaguqgUaR7',
+    };
+
+    const uca = new Claim('claim-cvc:Contact.phoneNumber-v1', value, '1');
+    const credential = new VC('credential-cvc:PhoneNumber-v1', '', null, [uca], '1');
+    const isValid = credential.nonCryptographicallySecureVerify();
+    expect(isValid).toBeTruthy();
+  });
+
+  it('Should verify an VC with cryptographic security', async (done) => {
+    const credJSon = require('./fixtures/PhoneNumber.json'); // eslint-disable-line
+    const credential = VC.fromJSON(credJSon);
+    expect(credential).toBeDefined();
+    const isValid = await credential.cryptographicallySecureVerify();
+    expect(isValid).toBeTruthy();
+    done();
+  });
 
   test('cred.verify(): VERIFY_LEVELS.PROOFS without expirationDate INVALID', () => {
     const credJSon = require('./fixtures/Cred1.json'); // eslint-disable-line

--- a/src/creds/VerifiableCredential.js
+++ b/src/creds/VerifiableCredential.js
@@ -536,6 +536,33 @@ function VerifiableCredentialBaseConstructor(identifier, issuer, expiryIn, ucas,
   };
 
   /**
+   * Non cryptographically secure verify the Credential
+   * Performs a proofs verification only.
+   * @return true if verified, false otherwise.
+   */
+  this.nonCryptographicallySecureVerify = () => this.verifyProofs();
+
+  /**
+   * Cryptographically secure verify the Credential.
+   * Performs a non cryptographically secure verification, attestantion check and signature validation.
+   * @return true if verified, false otherwise.
+   */
+  this.cryptographicallySecureVerify = async () => {
+    if (!this.nonCryptographicallySecureVerify()) {
+      return false;
+    }
+    const attestationCheck = await this.verifyAttestation();
+    if (!attestationCheck) {
+      return false;
+    }
+    const signatureCheck = await this.verifySignature();
+    if (!signatureCheck) {
+      return false;
+    }
+    return true;
+  };
+
+  /**
    * This method checks if the signature matches for the root of the Merkle Tree
    * @return true or false for the validation
    */


### PR DESCRIPTION
Implement new methods to verify credentials:
- `nonCryptographicallySecureVerify`: (sync) non cryptographically secure verify the Credential. Performs a proofs verification only.
- `cryptographicallySecureVerify`: (async)  cryptographically secure verify the Credential. Performs a non cryptographically secure verification, attestation check and signature validation.
