### PR TITLE
ID-1319 expose getClaimIdentifier

### DIFF
--- a/__test__/claim/Claim.test.js
+++ b/__test__/claim/Claim.test.js
@@ -1,5 +1,5 @@
 const { UserCollectableAttribute } = require('@identity.com/uca');
-const { Claim } = require('../../src/claim/Claim');
+const { Claim, getClaimIdentifier } = require('../../src/claim/Claim');
 
 describe('Claim Constructions tests', () => {
   test('Claim construction should fails', () => {
@@ -312,5 +312,11 @@ describe('Claim Constructions tests', () => {
     expect(evidencesClaimForAliasUCA.identifier).toEqual(evidencesClaim.identifier);
     expect(evidencesClaimForAliasUCA.getPlainValue()).toEqual(evidencesClaim.getPlainValue());
     expect(evidencesClaim.identifier).toBe('claim-cvc:Document.evidences-v1');
+  });
+
+  test('Should return a Claim identifier for the UCA identifier', () => {
+    const ucaIdentifier = 'cvc:Identity:address';
+    const claimIdentifier = getClaimIdentifier(ucaIdentifier, 'v1');
+    expect(claimIdentifier).toBe('claim-cvc:Identity.address-v1');
   });
 });

--- a/src/claim/Claim.js
+++ b/src/claim/Claim.js
@@ -302,4 +302,9 @@ function mixinIdentifiers(UCA) {
   return UCA;
 }
 
-module.exports = { Claim: mixinIdentifiers(Claim), definitions, getBaseIdentifiers };
+module.exports = {
+  Claim: mixinIdentifiers(Claim),
+  definitions,
+  getBaseIdentifiers,
+  getClaimIdentifier: adaptIdentifierIfNeeded,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-const { Claim } = require('./claim/Claim');
+const { Claim, getClaimIdentifier } = require('./claim/Claim');
 const VC = require('./creds/VerifiableCredential');
 const { initServices, services } = require('./services/index');
 const isValidGlobalIdentifier = require('./isValidGlobalIdentifier');
@@ -24,6 +24,7 @@ function CredentialCommons() {
   this.constants = constants;
   this.claimDefinitions = claimDefinitions;
   this.credentialDefinitions = credentialDefinitions;
+  this.getClaimIdentifier = getClaimIdentifier;
   return this;
 }
 


### PR DESCRIPTION
This exposes the function `getClaimIdentifier` required to transform a UCA identifier into a Claim identifier.