### PR TITLE
quickfix to better handle time deltas like `-21y`

### DIFF
--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -36,7 +36,7 @@ const signAttestationSubject = (subject, xprv, xpub) => {
 describe('Unit tests for Verifiable Credentials', () => {
   test('Dont construct undefined Credentials', () => {
     function createCredential() {
-      const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+      const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
       const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
       return new VC('cvc:cred:Test', uuidv4(), null, [name, dob], '1');
     }
@@ -45,7 +45,7 @@ describe('Unit tests for Verifiable Credentials', () => {
 
   test('Dont construct Credentials with wrong version', () => {
     function createCredential() {
-      const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+      const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
       const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
       return new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '2');
     }
@@ -53,13 +53,13 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   test('New Defined Credentials', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred).toBeDefined();
-    expect(cred.claim.identity.name.givenNames).toBe('Joao');
-    expect(cred.claim.identity.name.otherNames).toBe('Barbosa');
-    expect(cred.claim.identity.name.familyNames).toBe('Santos');
+    expect(cred.claim.identity.name.givenNames).toBe('Max');
+    expect(cred.claim.identity.name.otherNames).toBe('Abc');
+    expect(cred.claim.identity.name.familyNames).toBe('Mustermann');
     expect(cred.claim.identity.dateOfBirth.day).toBe(20);
     expect(cred.claim.identity.dateOfBirth.month).toBe(3);
     expect(cred.claim.identity.dateOfBirth.year).toBe(1978);
@@ -69,13 +69,13 @@ describe('Unit tests for Verifiable Credentials', () => {
   // This test was skipped cause in the current definitions we don't have this case any more
   test.skip('should validate new defined credentials with the obligatory Meta:expirationDate UCA with'
     + ' null value', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred).toBeDefined();
-    expect(cred.claim.identity.name.givenNames).toBe('Joao');
+    expect(cred.claim.identity.name.givenNames).toBe('Max');
     expect(cred.claim.identity.name.otherNames).toBeUndefined();
-    expect(cred.claim.identity.name.familyNames).toBe('Santos');
+    expect(cred.claim.identity.name.familyNames).toBe('Mustermann');
     expect(cred.claim.identity.dateOfBirth.day).toBe(20);
     expect(cred.claim.identity.dateOfBirth.month).toBe(3);
     expect(cred.claim.identity.dateOfBirth.year).toBe(1978);
@@ -87,13 +87,13 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   test('New Expirable Credentials', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), '-1d', [name, dob], '1');
     expect(cred).toBeDefined();
-    expect(cred.claim.identity.name.givenNames).toBe('Joao');
-    expect(cred.claim.identity.name.otherNames).toBe('Barbosa');
-    expect(cred.claim.identity.name.familyNames).toBe('Santos');
+    expect(cred.claim.identity.name.givenNames).toBe('Max');
+    expect(cred.claim.identity.name.otherNames).toBe('Abc');
+    expect(cred.claim.identity.name.familyNames).toBe('Mustermann');
     expect(cred.claim.identity.dateOfBirth.day).toBe(20);
     expect(cred.claim.identity.dateOfBirth.month).toBe(3);
     expect(cred.claim.identity.dateOfBirth.year).toBe(1978);
@@ -105,14 +105,14 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   test('New Defined Credentials return the incorrect global Credential Identifier', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred.getGlobalIdentifier()).toBe('credential-credential-cvc:Identity-v1-1');
   });
 
   it('should request an anchor for Credential and return an temporary attestation', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), '-1d', [name, dob], '1');
     return cred.requestAnchor().then((updated) => {
@@ -125,7 +125,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should refresh an temporary anchoring with an permanent one', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
 
@@ -149,9 +149,9 @@ describe('Unit tests for Verifiable Credentials', () => {
 
   test('Filter claims from Identity Name', () => {
     const civIdentityName = {
-      givenNames: 'Joao',
-      otherNames: 'Barbosa',
-      familyNames: 'Santos',
+      givenNames: 'Max',
+      otherNames: 'Abc',
+      familyNames: 'Mustermann',
     };
 
     const civIdentityDateOfBirth = {
@@ -512,7 +512,7 @@ describe('Unit tests for Verifiable Credentials', () => {
     const credJSon = require('./fixtures/Email.json'); // eslint-disable-line
     const cred = VC.fromJSON(credJSon);
     expect(cred).toBeDefined();
-    cred.claim.contact.email.username = 'jpsantos';
+    cred.claim.contact.email.username = 'jpMustermann';
     expect(cred.verifyProofs()).toBeFalsy();
   });
 
@@ -713,7 +713,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should have a empty "granted" field just after construct a VC', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
 
@@ -734,7 +734,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should throw exception id ".grantUsageFor()" request without proper ".requestAnchor()" first', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
 
@@ -752,7 +752,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should have a filled "granted" field after ".grantUsageFor()" request', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     await cred.requestAnchor();
@@ -781,7 +781,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should verifyGrant() accordingly', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     const anchoredCred = await cred.requestAnchor();
@@ -810,7 +810,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should fail verifyGrant() with a invalid "granted" token', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     const anchoredCred = await cred.requestAnchor();
@@ -843,7 +843,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should verify a granted credential json with requesterGrantVerify', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     const anchoredCred = await cred.requestAnchor();
@@ -871,7 +871,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should fail to verify a credential json with invalid granted token with requesterGrantVerify', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     const anchoredCred = await cred.requestAnchor();
@@ -903,7 +903,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should verify() with maximum level of GRANTED', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     const anchoredCred = await cred.requestAnchor();
@@ -932,7 +932,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should fail verify() with maximum level of GRANTED if granted is invalid', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     const anchoredCred = await cred.requestAnchor();
@@ -1003,7 +1003,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('should revoke the permanent anchor and succed verification', async (done) => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     await cred.requestAnchor();
@@ -1029,30 +1029,30 @@ describe('Unit tests for Verifiable Credentials', () => {
 
 
   it('Should match with one constraint', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred.isMatch({
       claims: [
-        { path: 'identity.name.givenNames', is: { $eq: 'Joao' } },
+        { path: 'identity.name.givenNames', is: { $eq: 'Max' } },
       ],
     })).toBeTruthy();
   });
 
   it('Should match with two constraint', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred.isMatch({
       claims: [
-        { path: 'identity.name.givenNames', is: { $eq: 'Joao' } },
-        { path: 'identity.name.otherNames', is: { $eq: 'Barbosa' } },
+        { path: 'identity.name.givenNames', is: { $eq: 'Max' } },
+        { path: 'identity.name.otherNames', is: { $eq: 'Abc' } },
       ],
     })).toBeTruthy();
   });
 
   it('Should match with gt constraint', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred.isMatch({
@@ -1063,7 +1063,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('Should match constraints targeting the parent properties of dates', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred.isMatch({
@@ -1073,24 +1073,37 @@ describe('Unit tests for Verifiable Credentials', () => {
     })).toBeTruthy();
   });
 
+  const getExactYearsAgo = (yearDelta) => {
+    const exactYearsAgo = new Date();
+    exactYearsAgo.setFullYear(new Date().getFullYear() - yearDelta);
+    return exactYearsAgo;
+  };
+
+  const dateToDOBClaim = (date) => {
+    const dobClaim = { day: date.getDate(), month: date.getMonth() + 1, year: date.getFullYear() };
+    return new Claim.IdentityDateOfBirth(dobClaim);
+  };
+
   it('Should match constraints targeting the parent properties and string deltas', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
-    const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
+    const exactlyFortyYearsAgo = getExactYearsAgo(40);
+    const dob = dateToDOBClaim(exactlyFortyYearsAgo);
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
+
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred.isMatch({
       claims: [
-        { path: 'identity.dateOfBirth', is: { $lte: '-21y' } },
+        { path: 'identity.dateOfBirth', is: { $lte: '-40y' } },
       ],
     })).toBeTruthy();
   });
 
   it('Should not match', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Joao', otherNames: 'Barbosa', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Max', otherNames: 'Abc', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 20, month: 3, year: 1978 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred.isMatch({
       claims: [
-        { path: 'identity.name.first', is: { $eq: 'Savio' } },
+        { path: 'identity.name.first', is: { $eq: 'Maxime' } },
       ],
     })).toBeFalsy();
   });
@@ -1370,7 +1383,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   });
 
   it('Should construct a VC with no evidence provided', () => {
-    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1');
     expect(cred).toBeDefined();
@@ -1385,7 +1398,7 @@ describe('Unit tests for Verifiable Credentials', () => {
       subjectPresence: 'Digital',
       documentPresence: 'Digital',
     };
-    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     expect(cred.evidence).toBeDefined();
@@ -1411,7 +1424,7 @@ describe('Unit tests for Verifiable Credentials', () => {
         documentPresence: 'Digital',
       },
     ];
-    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     expect(cred.evidence).toBeDefined();
@@ -1430,7 +1443,7 @@ describe('Unit tests for Verifiable Credentials', () => {
         other: 'other',
       },
     ];
-    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     expect(cred.evidence).toBeDefined();
@@ -1447,7 +1460,7 @@ describe('Unit tests for Verifiable Credentials', () => {
         documentPresence: 'Digital',
       },
     ];
-    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+    const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
     const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
     const cred = new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     expect(cred.evidence).toBeDefined();
@@ -1465,7 +1478,7 @@ describe('Unit tests for Verifiable Credentials', () => {
       },
     ];
     function createCredential() {
-      const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+      const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
       const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
       return new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     }
@@ -1484,7 +1497,7 @@ describe('Unit tests for Verifiable Credentials', () => {
       },
     ];
     function createCredential() {
-      const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+      const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
       const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
       return new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     }
@@ -1503,7 +1516,7 @@ describe('Unit tests for Verifiable Credentials', () => {
       },
     ];
     function createCredential() {
-      const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Santos' });
+      const name = new Claim.IdentityName({ givenNames: 'Neymar', otherNames: 'Jr', familyNames: 'Mustermann' });
       const dob = new Claim.IdentityDateOfBirth({ day: 5, month: 2, year: 1992 });
       return new VC('credential-cvc:Identity-v1', uuidv4(), null, [name, dob], '1', evidence);
     }
@@ -1513,7 +1526,7 @@ describe('Unit tests for Verifiable Credentials', () => {
   it('Should create credential if all claims are provided', () => {
     const type = new Claim('claim-cvc:Document.type-v1', 'passport', '1');
     const number = new Claim('claim-cvc:Document.number-v1', '123', '1');
-    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
+    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Maxime' }, '1');
     const gender = new Claim('claim-cvc:Document.gender-v1', 'M', '1');
     const nationality = new Claim('claim-cvc:Document.nationality-v1', 'Brazilian', '1');
     const placeOfBirth = new Claim('claim-cvc:Document.placeOfBirth-v1', 'Brazil', '1');
@@ -1546,7 +1559,7 @@ describe('Unit tests for Verifiable Credentials', () => {
 
   it('Should create credential if non-required claims are missing', () => {
     const type = new Claim('claim-cvc:Document.type-v1', 'passport', '1');
-    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
+    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Maxime' }, '1');
     const issueCountry = new Claim('claim-cvc:Document.issueCountry-v1', 'Brazil', '1');
     const dateOfBirthValue = { day: 20, month: 3, year: 1978 };
     const dateOfBirth = new Claim('claim-cvc:Document.dateOfBirth-v1', dateOfBirthValue, '1');
@@ -1558,7 +1571,7 @@ describe('Unit tests for Verifiable Credentials', () => {
 
   it('Should throw exception on credential creation if required uca is missing', () => {
     const type = new Claim('claim-cvc:Document.type-v1', 'passport', '1');
-    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Lucas' }, '1');
+    const name = new Claim('claim-cvc:Document.name-v1', { givenNames: 'Maxime' }, '1');
     const issueCountry = new Claim('claim-cvc:Document.issueCountry-v1', 'Brazil', '1');
 
     const ucas = [type, name, issueCountry];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8860,6 +8860,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment-mini": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment-mini/-/moment-mini-2.24.0.tgz",
+      "integrity": "sha512-9ARkWHBs+6YJIvrIp0Ik5tyTTtP9PoV0Ssu2Ocq5y9v8+NOOpWiRshAp8c4rZVWTOe+157on/5G+zj5pwIQFEQ=="
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "lodash": "^4.17.15",
     "md5": "^2.2.1",
     "merkle-tools": "^1.4.0",
+    "moment-mini": "^2.24.0",
     "node-fetch": "^2.6.0",
     "randexp": "^0.4.9",
     "randomstring": "^1.1.5",

--- a/src/creds/VerifiableCredential.js
+++ b/src/creds/VerifiableCredential.js
@@ -10,10 +10,13 @@ const { Claim } = require('../claim/Claim');
 const definitions = require('./definitions');
 const claimDefinitions = require('../claim/definitions');
 const { services } = require('../services');
+const time = require('../timeHelper');
 
 function sha256(string) {
   return sjcl.codec.hex.fromBits(sjcl.hash.sha256.hash(string));
 }
+
+const convertTimestamp = delta => time.applyDeltaToDate(delta).getTime() / 1000;
 
 function getClaimPath(identifier, claimsPathRef) {
   const sufix = Claim.getPath(identifier);
@@ -688,7 +691,7 @@ function VerifiableCredentialBaseConstructor(identifier, issuer, expiryIn, ucas,
         _.set(claims, path, transformDate(pathValue));
         // transforms delta values like "-18y" to a proper timestamp
         // eslint-disable-next-line no-confusing-arrow
-        _.set(constraint, path, _.mapValues(constraint[path], obj => _.isString(obj) ? timestamp.now(obj) : obj));
+        _.set(constraint, path, _.mapValues(constraint[path], obj => _.isString(obj) ? convertTimestamp(obj) : obj));
       }
       result = (sift.indexOf(constraint, [claims]) > -1);
       return result;

--- a/src/creds/VerifiableCredential.js
+++ b/src/creds/VerifiableCredential.js
@@ -692,6 +692,7 @@ function VerifiableCredentialBaseConstructor(identifier, issuer, expiryIn, ucas,
         // transforms delta values like "-18y" to a proper timestamp
         // eslint-disable-next-line no-confusing-arrow
         _.set(constraint, path, _.mapValues(constraint[path], obj => _.isString(obj) ? convertTimestamp(obj) : obj));
+        // _.set(constraint, path, _.mapValues(constraint[path], obj => _.isString(obj) ? timestamp.now(obj) : obj));
       }
       result = (sift.indexOf(constraint, [claims]) > -1);
       return result;

--- a/src/timeHelper.js
+++ b/src/timeHelper.js
@@ -1,0 +1,37 @@
+const moment = require('moment-mini');
+
+const unitMapper = {
+  y: 'y',
+  m: 'M',
+  w: 'w',
+  d: 'd',
+};
+
+/**
+ * Convert a delta string like "21y" to a moment Duration object
+ * @param delta
+ * @return {moment.Duration}
+ */
+const timeDeltaToMomentDuration = (delta) => {
+  const matched = delta.match(/(-?\d+)(\w)/);
+
+  if (!matched) throw new Error(`Invalid time delta ${delta}`);
+
+  const [, amount, unit] = matched;
+
+  return moment.duration(parseInt(amount, 10), unitMapper[unit]);
+};
+
+/**
+ * Given a time delta like "-21y", apply it to the passed in date object, or the current time
+ * @param delta String
+ * @param date Date
+ * @return {Date}
+ */
+const applyDeltaToDate = (delta, date = new Date()) => moment(date)
+  .add(timeDeltaToMomentDuration(delta))
+  .toDate();
+
+module.exports = {
+  applyDeltaToDate,
+};


### PR DESCRIPTION
The `unix-timestap` has a bug when transforming string deltas to a timestamp. `moment` in the other hand does it right.
So THIS includeS a new timeHelper that uses `moment-mini` to handle that conversion.