### PR TITLE
remove `Medical` from Covid19 credential defn

### DIFF
--- a/__test__/creds/VerifiableCredential.test.js
+++ b/__test__/creds/VerifiableCredential.test.js
@@ -499,7 +499,7 @@ describe('Unit tests for Verifiable Credentials', () => {
     const covidClaim = new Claim('claim-cvc:Medical.covid19-v1', covidDetails);
 
     const credential = new VC(
-      'credential-cvc:Medical.Covid19-v1', '', null, [covidClaim], '1',
+      'credential-cvc:Covid19-v1', '', null, [covidClaim], '1',
     );
     expect(credential).toBeDefined();
     expect(credential.verifyProofs()).toBeTruthy();

--- a/src/creds/definitions.js
+++ b/src/creds/definitions.js
@@ -126,7 +126,7 @@ const definitions = [
     ],
   },
   {
-    identifier: 'credential-cvc:Medical.Covid19-v1',
+    identifier: 'credential-cvc:Covid19-v1',
     version: '1',
     depends: [
       'claim-cvc:Medical.covid19-v1',


### PR DESCRIPTION
Rename Covid19 credential to be like the others with no 'Medical' component in its title, so it's now: `credential-cvc:Covid19-v1` rather than `credential-cvc:Medical.Covid19-v1`



