### PR TITLE
Fix - revert plugin to the dummy implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3685,6 +3685,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
       "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9886,7 +9887,8 @@
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -11694,7 +11696,8 @@
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
     },
     "require-main-filename": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "audit-ci": "audit-ci --config audit-ci.json"
   },
   "devDependencies": {
+    "ajv": "^7.0.3",
     "audit-ci": "^3.1.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.24.1",
@@ -62,7 +63,6 @@
   },
   "dependencies": {
     "@identity.com/uca": "^1.0.19",
-    "ajv": "^7.0.3",
     "babel-runtime": "^6.26.0",
     "bitcoinjs-lib": "git+https://github.com/dabura667/bitcoinjs-lib.git#bcash330",
     "bluebird": "^3.7.2",

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -2,7 +2,7 @@
  * Services IoC modules
  */
 const Bottle = require('bottlejs');
-const { CurrentCivicAnchor } = require('./DefaultAnchorServiceImpl.js');
+const { CurrentCivicAnchor } = require('./DummyAnchorServiceImpl.js');
 const logger = require('../logger');
 const HttpServiceConstructor = require('./httpService');
 const config = require('./config');


### PR DESCRIPTION
Revert the anchor plugin to use the dummy implementation and move _avj_ dependencies to _devDependencies_.