### PR TITLE
BUG FIX: max/min and boolean params

### DIFF
--- a/__test__/services/AggregationService.test.js
+++ b/__test__/services/AggregationService.test.js
@@ -26,10 +26,34 @@ describe('Aggregation Service', () => {
     expect(result).toStrictEqual([{ k: 'a' }]);
   });
 
+  it('should  return the first elements using boolean', () => {
+    const collection = [{ k: 'a' }, { k: 'b' }, { k: 'c' }];
+    const result = aggregate(collection, [{ $first: true }]);
+    expect(result).toStrictEqual([{ k: 'a' }]);
+  });
+
   it('should  return the last elements only', () => {
     const collection = [{ k: 'a' }, { k: 'b' }, { k: 'c' }];
     const result = aggregate(collection, [{ $last: 'true' }]);
     expect(result).toStrictEqual([{ k: 'c' }]);
+  });
+
+  it('should  return the last elements using boolean', () => {
+    const collection = [{ k: 'a' }, { k: 'b' }, { k: 'c' }];
+    const result = aggregate(collection, [{ $last: true }]);
+    expect(result).toStrictEqual([{ k: 'c' }]);
+  });
+
+  it('should  return the max elements only', () => {
+    const collection = [{ k: 'a' }, { k: 'b' }, { k: 'c' }];
+    const result = aggregate(collection, [{ $max: 'k' }]);
+    expect(result).toStrictEqual([{ k: 'c' }]);
+  });
+
+  it('should  return the min elements only', () => {
+    const collection = [{ k: 'a' }, { k: 'b' }, { k: 'c' }];
+    const result = aggregate(collection, [{ $min: 'k' }]);
+    expect(result).toStrictEqual([{ k: 'a' }]);
   });
 
   it('should  return in ascending order ', () => {

--- a/src/AggregationHandler.js
+++ b/src/AggregationHandler.js
@@ -5,7 +5,7 @@ const validateEmptyParametersOperators = (parameters) => {
   return true;
 };
 const validateNotEmptyParametersOperators = (parameters) => {
-  if (_.isEmpty(parameters)) { throw new Error('parameters should not be empty'); }
+  if (!parameters && _.isEmpty(parameters)) { throw new Error('parameters should not be empty'); }
   return true;
 };
 const validatePathParametersOperators = (parameters) => {
@@ -34,9 +34,9 @@ const AGGREGATION_OPERATORS_MAP = {
   $limit: (collection, params) => (validateNumberParametersOperators(params)
     ? [...(_.slice(collection, 0, params))] : null),
   $min: (collection, params) => (validatePathParametersOperators(params)
-    ? [...(_.minBy(collection, params))] : null),
+    ? [(_.minBy(collection, params))] : null),
   $max: (collection, params) => (validatePathParametersOperators(params)
-    ? [...(_.maxBy(collection, params))] : null),
+    ? [(_.maxBy(collection, params))] : null),
   $first: (collection, params) => (validateNotEmptyParametersOperators(params)
     ? [_.first(collection)] : null),
   $last: (collection, params) => (validateNotEmptyParametersOperators(params)


### PR DESCRIPTION
- fixes the $max and min operator
- handle both 'true' and true as parameters