### PR TITLE
CIV-3145 - Add error code for anchoring failures

### DIFF
--- a/AUDIT.md
+++ b/AUDIT.md
@@ -11,5 +11,8 @@ Whenever you whitelist a specific advisory it is required to refer it to here an
 
 | #    | Level | Module | Title | Explanation |
 |------|-------|---------|------|-------------|
-| 1500 | Low | babel-minify>yargs-parser | Prototype Pollution | dev dependency only |
+| 565 | Moderate | npm>ssri | Regular Expression Denial of Service | dev dependency only |
 | 786 | Low | babel-cli > chokidar > anymatch > micromatch > braces | Regular Expression Denial of Service | dev dependency only |
+| 1500 | Low | babel-minify>yargs-parser | Prototype Pollution | dev dependency only |
+| 1654 | Moderate | npm>libnpx>y18n | Regular Expression Denial of Service | dev dependency only |
+| 1677 | Moderate | npm>hosted-git-info | Regular Expression Denial of Service | dev dependency only |

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
   "low": true,
   "package-manager": "auto",
   "report": true,
-  "allowlist": [786, 1500]
+  "allowlist": [565, 786, 1500, 1654, 1677]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5449,9 +5449,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -8661,9 +8661,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "flat": "^4.1.0",
     "inquirer": "^7.3.3",
     "json-format": "^1.0.1",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "md5": "^2.3.0",
     "merkle-tools": "^1.4.1",
     "moment-mini": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@identity.com/credential-commons",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Identity.com Community",
   "license": "MIT",
   "description": "Verifiable Credential and Attestation Library",

--- a/src/errors/definitions.js
+++ b/src/errors/definitions.js
@@ -181,6 +181,13 @@ const ErrorCodes = {
   ERROR_IDV_CREDENTIAL_INVALID_SIGNATURE: 'error.idv.credential.invalid.signature',
 
   /**
+   * Reason: Could not anchor the credential,
+   * possibly caused by errors while connecting to an external provider
+   * Troubleshooting: Try again later
+   */
+  ERROR_IDV_CREDENTIAL_FAILED_ANCHORING: 'error.idv.credential.failed.anchoring',
+
+  /**
    * Reason: The credential has already been signed.
    * Troubleshooting: The credential is already signed. You must not sign it again
    */
@@ -417,7 +424,6 @@ const ErrorCodes = {
    * Troubleshooting: Retry the network call again
    */
   ERROR_RETRYABLE_NETWORK_ERROR: 'error.retryable.network',
-
 };
 
 /**


### PR DESCRIPTION
Added ERROR_IDV_CREDENTIAL_FAILED_ANCHORING (`error.idv.credential.failed.anchoring`) to the IDV errors definition.

Fix audit issues.