### PR TITLE
CIV-3154 Merkletree Sign and Verify

### DIFF
--- a/__test__/CredentialSignerVerifier.test.js
+++ b/__test__/CredentialSignerVerifier.test.js
@@ -42,6 +42,7 @@ describe('CredentialSignerVerifier Tests', () => {
           },
         },
       };
+
       expect(signerVerifier.isSignatureValid(toVerify)).toBeTruthy();
     });
 

--- a/__test__/CredentialSignerVerifier.test.js
+++ b/__test__/CredentialSignerVerifier.test.js
@@ -1,0 +1,145 @@
+/* eslint-disable max-len */
+
+const { HDNode } = require('bitcoinjs-lib');
+const CredentialSignerVerifier = require('../src/creds/CredentialSignerVerifier');
+
+const SEED = 'f6d466fd58c20ff964673522083efebf';
+const prvBase58 = 'xprv9s21ZrQH143K4aBUwUW6GVec7Y6oUEBqrt2WWaXyxjh2pjofNc1of44BLufn4p1t7Jq4EPzm5C9sRxCuBYJdHu62jhgfyPm544sNjtH7x8S';
+
+const pubBase58 = 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD';
+
+describe('CredentialSignerVerifier Tests', () => {
+  describe('Using a ECKeyPair', () => {
+    let keyPair;
+    let signerVerifier;
+
+    beforeAll(() => {
+      keyPair = HDNode.fromSeedHex(SEED);
+      signerVerifier = new CredentialSignerVerifier({ keyPair });
+    });
+
+    it('Should sign and verify', () => {
+      const toSign = { merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' };
+      const signature = signerVerifier.sign(toSign);
+      expect(signature).toBeDefined();
+      const toVerify = {
+        proof: {
+          ...toSign,
+          merkleRootSignature: signature,
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeTruthy();
+    });
+
+    it('Should verify', () => {
+      const toVerify = {
+        proof: {
+          merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b666',
+          merkleRootSignature: {
+            algo: 'ec256k1',
+            pubBase58: 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD',
+            signature: '3045022100e7f0921491e8da2759b24047443325483ac023795683dc3b91c78d0566a1159602206fd4e80982fd83705932543d02bc6abd079446bf4ec7b5d9fba4f7f5363bd6fa',
+          },
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeTruthy();
+    });
+
+    it('Should not verify', () => {
+      const toVerify = {
+        proof: {
+          merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b666',
+          merkleRootSignature: {
+            algo: 'ec256k1',
+            pubBase58: 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD',
+            signature: 'fa3e022100e7f0921491e8da2759b24047443325483ac023795683dc3b91c78d0566a1159602206fd4e80982fd83705932543d02bc6abd079446bf4ec7b5d9fba4f7f5363bd6fa',
+          },
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeFalsy();
+    });
+  });
+  describe('Using a prvBase58', () => {
+    let signerVerifier;
+
+    beforeAll(() => {
+      signerVerifier = new CredentialSignerVerifier({ prvBase58 });
+    });
+
+    it('Should sign and verify', () => {
+      const toSign = { merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' };
+      const signature = signerVerifier.sign(toSign);
+      expect(signature).toBeDefined();
+      const toVerify = {
+        proof: {
+          ...toSign,
+          merkleRootSignature: signature,
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeTruthy();
+    });
+
+    it('Should verify', () => {
+      const toVerify = {
+        proof: {
+          merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b666',
+          merkleRootSignature: {
+            algo: 'ec256k1',
+            pubBase58: 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD',
+            signature: '3045022100e7f0921491e8da2759b24047443325483ac023795683dc3b91c78d0566a1159602206fd4e80982fd83705932543d02bc6abd079446bf4ec7b5d9fba4f7f5363bd6fa',
+          },
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeTruthy();
+    });
+
+    it('Should not verify', () => {
+      const toVerify = {
+        proof: {
+          merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b666',
+          merkleRootSignature: {
+            algo: 'ec256k1',
+            pubBase58: 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD',
+            signature: 'fa3e022100e7f0921491e8da2759b24047443325483ac023795683dc3b91c78d0566a1159602206fd4e80982fd83705932543d02bc6abd079446bf4ec7b5d9fba4f7f5363bd6fa',
+          },
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeFalsy();
+    });
+  });
+  describe('Using a pubBase58', () => {
+    let signerVerifier;
+
+    beforeAll(() => {
+      signerVerifier = new CredentialSignerVerifier({ pubBase58 });
+    });
+
+    it('Should verify', () => {
+      const toVerify = {
+        proof: {
+          merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b666',
+          merkleRootSignature: {
+            algo: 'ec256k1',
+            pubBase58: 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD',
+            signature: '3045022100e7f0921491e8da2759b24047443325483ac023795683dc3b91c78d0566a1159602206fd4e80982fd83705932543d02bc6abd079446bf4ec7b5d9fba4f7f5363bd6fa',
+          },
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeTruthy();
+    });
+
+    it('Should not verify', () => {
+      const toVerify = {
+        proof: {
+          merkleRoot: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b666',
+          merkleRootSignature: {
+            algo: 'ec256k1',
+            pubBase58: 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD',
+            signature: 'fa3e022100e7f0921491e8da2759b24047443325483ac023795683dc3b91c78d0566a1159602206fd4e80982fd83705932543d02bc6abd079446bf4ec7b5d9fba4f7f5363bd6fa',
+          },
+        },
+      };
+      expect(signerVerifier.isSignatureValid(toVerify)).toBeFalsy();
+    });
+  });
+});

--- a/src/creds/CredentialSignerVerifier.js
+++ b/src/creds/CredentialSignerVerifier.js
@@ -1,0 +1,60 @@
+const _ = require('lodash');
+const { HDNode, ECSignature } = require('bitcoinjs-lib');
+
+class CredentialSignerVerifier {
+  /**
+   * Creates a new instance of a CredentialSignerVerifier
+   *
+   * @param options.keyPair any instace that implements sign and verify interface
+   * or
+   * @param options.prvBase58 bse58 serialized private key
+   * or for verification only
+   * @param options.pubBase58 bse58 serialized public key
+   */
+  constructor(options) {
+    if (_.isEmpty(options.keyPair) && _.isEmpty(options.prvBase58) && _.isEmpty(options.pubBase58)) {
+      throw new Error('Either a keyPair, prvBase58 or pubBase58(to verify only) is required');
+    }
+    this.keyPair = options.keyPair || HDNode.fromBase58(options.prvBase58 || options.pubBase58);
+  }
+
+  /**
+   * Verify is a credential has a valid merkletree signature, using a pinned pubkey
+   * @param credential
+   * @returns {*|boolean}
+   */
+  isSignatureValid(credential) {
+    if (_.isEmpty(credential.proof)
+        || _.isEmpty(credential.proof.merkleRoot)
+        || _.isEmpty(credential.proof.merkleRootSignature)) {
+      throw Error('Invalid Credential Proof Schema');
+    }
+
+    try {
+      const signatureHex = _.get(credential, 'proof.merkleRootSignature.signature');
+      const signature = signatureHex ? ECSignature.fromDER(Buffer.from(signatureHex, 'hex')) : null;
+      const merkleRoot = _.get(credential, 'proof.merkleRoot');
+      return (signature && merkleRoot) ? this.keyPair.verify(Buffer.from(merkleRoot, 'hex'), signature) : false;
+    } catch (error) {
+      // verify throws in must cases but we want to return false
+      return false;
+    }
+  }
+
+  /**
+   * Create a merkleRootSignature object by signing with a pinned private key
+   * @param proof
+   * @returns {{signature, pubBase58: *, algo: string}}
+   */
+  sign(proof) {
+    const hash = Buffer.from(proof.merkleRoot, 'hex');
+    const signature = this.keyPair.sign(hash);
+    return {
+      algo: 'ec256k1',
+      pubBase58: this.keyPair.neutered().toBase58(),
+      signature: signature.toDER().toString('hex'),
+    };
+  }
+}
+
+module.exports = CredentialSignerVerifier;

--- a/src/creds/CredentialSignerVerifier.js
+++ b/src/creds/CredentialSignerVerifier.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const { HDNode, ECSignature } = require('bitcoinjs-lib');
 
+const SIGNATURE_ALGO = 'ec256k1';
 class CredentialSignerVerifier {
   /**
    * Creates a new instance of a CredentialSignerVerifier
@@ -50,7 +51,7 @@ class CredentialSignerVerifier {
     const hash = Buffer.from(proof.merkleRoot, 'hex');
     const signature = this.keyPair.sign(hash);
     return {
-      algo: 'ec256k1',
+      algo: SIGNATURE_ALGO,
       pubBase58: this.keyPair.neutered().toBase58(),
       signature: signature.toDER().toString('hex'),
     };

--- a/src/creds/CvcMerkleProof.js
+++ b/src/creds/CvcMerkleProof.js
@@ -14,16 +14,16 @@ class CvcMerkleProof {
     return 16;
   }
 
-  constructor(ucas) {
+  constructor(ucas, credentialSigner = null) {
     const withRandomUcas = CvcMerkleProof.padTree(ucas);
     this.type = 'CvcMerkleProof2018';
     this.merkleRoot = null;
     this.anchor = 'TBD (Civic Blockchain Attestation)';
     this.leaves = CvcMerkleProof.getAllAttestableValue(withRandomUcas);
-    this.buildMerkleTree();
+    this.buildMerkleTree(credentialSigner);
   }
 
-  buildMerkleTree() {
+  buildMerkleTree(credentialSigner = null) {
     const merkleTools = new MerkleTools();
     const hashes = _.map(this.leaves, n => sha256(n.value));
     merkleTools.addLeaves(hashes);
@@ -34,6 +34,10 @@ class CvcMerkleProof {
     });
     this.leaves = _.filter(this.leaves, el => !(el.identifier === 'cvc:Random:node'));
     this.merkleRoot = merkleTools.getMerkleRoot().toString('hex');
+
+    if (credentialSigner) {
+      this.merkleRootSignature = credentialSigner.sign(this);
+    }
   }
 
   static padTree(nodes) {


### PR DESCRIPTION
This is to add a `merkleRootSignature` property in the credential `proof`. With that is possible to verifiy the full integrity of the credential merkletree without the need to an on chain anchor.

An example of a 
```
{
            algo: 'ec256k1',
            pubBase58: 'xpub661MyMwAqRbcH4Fx3W36ddbLfZwHsguhE6x7JxwbX5E1hY8ov9L4CrNfCCQpV8pVK64CVqkhYQ9QLFgkVAUqkRThkTY1R4GiWHNZtAFSVpD',
            signature: '3045022100e7f0921491e8da2759b24047443325483ac023795683dc3b91c78d0566a1159602206fd4e80982fd83705932543d02bc6abd079446bf4ec7b5d9fba4f7f5363bd6fa',
}
```
          

To get the `proof` signed like that an signer instance(must implement the `sign` function) needs to provided in the constructor. The signer is optional.

This also implements a CredentialSignerVerifier as reference and convenience implementation to sign and verify the credentials.   
          