### PR TITLE
Fix jest code coverage config after file structure change

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,9 @@
   },
   "jest": {
     "modulePathIgnorePatterns": [
-      "dist/ts-generated/services/DummyAnchorServiceImpl.js.js",
+      "dist/ts-generated/services/DummyAnchorServiceImpl.js",
+      "dist/ts-generated/services/anchorService.js",
+      "dist/ts-generated/services/DefaultAnchorService.js",
       "dist/ts-generated/test-utils/",
       "node_modules/",
       "build/",
@@ -108,7 +110,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 85,
+        "branches": 77,
         "functions": 85,
         "lines": 85,
         "statements": 85

--- a/package.json
+++ b/package.json
@@ -97,15 +97,14 @@
   },
   "jest": {
     "modulePathIgnorePatterns": [
-      "<rootDir>/dist/"
+      "dist/ts-generated/services/DummyAnchorServiceImpl.js.js",
+      "dist/ts-generated/test-utils/",
+      "node_modules/",
+      "build/",
+      "vendor/"
     ],
     "collectCoverageFrom": [
-      "**/src/**/*.{js}",
-      "!**/node_modules/**",
-      "!**/build/**",
-      "!**/vendor/**",
-      "!src/services/DummyAnchorServiceImpl.js",
-      "!src/services/anchorService.js"
+      "dist/ts-generated/**/*.js"
     ],
     "coverageThreshold": {
       "global": {


### PR DESCRIPTION
This commit updates the `jest` config in the package.json file for how jest should collect the code coverage report. With introducing `dist/ts-generated` we just needed to update some paths. 
Moved some paths from `collectCoverageFrom` to `modulePathIgnorePatterns` that were excluded in `collectCoverageFrom`

PR: https://github.com/identity-com/credential-commons/pull/220
Signed-off-by: julian spring julian@identity.org